### PR TITLE
Nitro in backend

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,40 +44,28 @@ def main(args):
 
     events = []
 
-    if args['--nobackend']:
-        with Nitro(domain) as nitro:
-            nitro.set_traps(True)
-            for event in nitro.listen():
-                ev_info = event.info()
-
-                if args['--stdout']:
-                    pprint(ev_info, width=1)
-                else:
-                    events.append(ev_info)
-
-                # stop properly by CTRL+C
-                if not run:
-                    break
-    else:
-        with Backend(domain) as backend:
-            backend.nitro.set_traps(True)
-            for event in backend.nitro.listen():
+    analyze_enabled = True if not args['--nobackend'] else False
+    with Backend(domain, analyze_enabled) as backend:
+        backend.nitro.set_traps(True)
+        for event in backend.nitro.listen():
+            ev_info = event.info()
+            if analyze_enabled:
                 syscall = backend.process_event(event)
                 ev_info = syscall.info()
 
-                if args['--stdout']:
-                    pprint(ev_info, width=1)
-                else:
-                    events.append(ev_info)
+            if args['--stdout']:
+                pprint(ev_info, width=1)
+            else:
+                events.append(ev_info)
 
-                # stop properly by CTRL+C
-                if not run:
-                    break
+            # stop properly by CTRL+C
+            if not run:
+                break
 
-        if events:
-            logging.info('Writing events')
-            with open('events.json', 'w') as f:
-                json.dump(events, f, indent=4)
+    if events:
+        logging.info('Writing events')
+        with open('events.json', 'w') as f:
+            json.dump(events, f, indent=4)
 
 
 

--- a/nitro/nitro.py
+++ b/nitro/nitro.py
@@ -75,6 +75,9 @@ class Nitro:
         return self
 
     def __exit__(self, type, value, traceback):
+        self.stop()
+
+    def stop(self):
         self.stop_listen()
         self.kvm_io.close()
 

--- a/nitro/nitro.py
+++ b/nitro/nitro.py
@@ -24,7 +24,7 @@ def find_qemu_pid(vm_name):
         # permission denied
         # find the PID using pgrep
         # pgrep --full to match the whole command line
-        cmd = ['pgrep', '--full', 'qemu.*-name {}'.format(vm_name)]
+        cmd = ['pgrep', '--full', 'qemu.*-name.*{}'.format(vm_name)]
         output = subprocess.check_output(cmd)
         try:
             pid = int(output)


### PR DESCRIPTION
Moved the `Nitro` object initialization into the `Backend`.

The end goal is to modify the callback API to make it look like this
~~~
def enter_NtOpenFile(backend, syscall):
~~~
including a new parameter, the `backend` itself.
This will allow the callback to query information of the `backend`, and even more, give instructions to `nitro`, like getting the register or setting them.

At the end, we allow the developer to change the syscall parameters on the fly (if they are stored in registers)