### PR TITLE
Refactor test api

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,36 +1,23 @@
+# Tests
+
+This directory contains the test suite for Nitro, based on the `Nose2` framework.
+
 # Requirements
 
+- `nose2`
 - `genisoimage`
+- dedicated test VM (_see Building test VMs_ section)
 
-# Testing
+# Setup
 
-The tests can be run with `nose2`
+The tests only targets `Windows_7_x64` for now.
 
-A test consist of the following operations:
+Also, the test procedure expects to find a VM named `nitro_win7x64` in libvirt `qemu:///system`.
+Here is how to build it.
 
-1. start the domain `nitro_win7x64`
-2. wait for the DHCP request to get the ip address via polling on `ip neigh`
-3. wait for WinRM service to be available
-4. set nitro traps and start listening to syscall events
-5. configure and insert a CDROM to execute a binary or a script
-6. wait for WinRM service to be closed
-7. stop the domain and the test
+## Building test VMs
 
-This is an example of the API used to build a test:
-
-~~~Python
-script = 'powershell -Command \"Get-ChildItem -Path C:\\windows\\system32"'
-self.cdrom.configure_test(script)
-cdrom_iso = self.cdrom.generate_iso()
-events, exec_time, nb_syscall = self.vm_test.run(cdrom_iso)
-logging.info('Test execution time {}'.format(exec_time))
-~~~
-
-use `nose2 -log-capture` to get the logging output
-
-# Building Test VMs
-
-In the `packer-windows` directory you will find a `packer` binary and 2 templates
+In the `packer-windows` directory you will find a `packer` binary and templates
 to build ready to test Windows VMs.
 
 The templates apply the following modifications:
@@ -41,26 +28,148 @@ The templates apply the following modifications:
 To build a vm, run `./packer build <template.json>`.
 Once the build is done, the image will be available in `packer-windows/output-qemu` directory.
 
-# Importing VMs
+_You can build the Windows 7 x64 VM here: `./packer build windows_7_x64`_
+
+## Importing VMs
 
 To easily import the vm in libvirt, you can use the script `import_libvirt.py`,
 which will do the following modifications:
 - create a storage pool named `nitro` associated with a subdirectory named `images` under `tests`
 - move the disk image from `output-qemu` to `images`
 - set the name of the vm to `nitro_<vm_name>`
-- optionnaly configure a custom QEMU binary
+- create a new VM based on `template_domain.xml`
+- specifiy custom QEMU binary if needed
+
+To import the test VM once `Packer` is done building it:
 
 ~~~
-Usage:
-  import_libvirt.py [--qemu=<path>] <qemu_image>
-
-Options:
-  -h --help         Show this screen.
-  --qemu=<path>     Path to custom QEMU binary
+./import_libvirt.py packer-windows/output-qemu/win7x64
 ~~~
 
-# Custom QEMU
+To specify a custom QEMU, if the `kvm-vmi` one is not installed in `/usr/bin/qemu-system-x86`, 
+use the `--qemu` switch
+~~~
+./import_libvirt.py --qemu /home/kvm-vmi/qemu/x86_64-softmmu/qemu-system-x86_64 packer-windows/output-qemu/win7x64
+~~~
 
-You will need to compile a custom QEMU from the `qemu` subdirectory which contains
-already the modifications to allow a read/write access to the guest memory.
-This allows `libvmi` to perform an introspection and `nitro` to analyze syscalls events.
+# Running tests
+
+Tests are run under the `nose2` framework. (_[documentation](http://nose2.readthedocs.io/en/latest/getting_started.html)_)
+
+Note: If you install the debian package `python3-nose2`, the executable is named `nose2-3`.
+
+Remember that you need a custom test VM named `nitro_win7x64` to run the tests.
+
+## Usage
+
+This will run all tests available in all the test files, quitely and display the overall result
+~~~
+$ nose2
+~~~
+
+You can ask `nose` to be a bit verbose and display which tests it is running with  `-v`
+~~~
+$ nose2 -v
+~~~
+
+You can also ask him to be more verbose by capturing the `logging` output, useful to debug and understand what is really happenning during the test.
+~~~
+$ nose2 -v --log-capture
+~~~
+
+## Running a specific test
+
+The `Nose2` test name is `test_file.TestClass.test_name`
+
+For example, if you want to run `test_hook_openkey` located in the `TestWindows` class inside the `test_windows.py`:
+
+~~~
+$ nose2 --log-capture test_windows.TestWindows.test_hook_openkey
+~~~
+
+## Test output
+
+Each test which is run will create a `<test_name>` directory under `tests/`, containing a least the `test.log` logging output.
+
+The Nitro events are also dumped there, usually in a file named `events.json`, if specified during the test.
+
+## General test behavior
+
+A test consists of the following operations:
+
+1. start the domain `nitro_win7x64`
+2. wait for the DHCP request to get the ip address
+3. wait for WinRM service to be available (_port_ `5985`)
+4. set nitro traps and start listening to syscall events
+5. configure and insert a CDROM to execute a binary or a script (_this is your test configuration_)
+6. wait for WinRM service to be closed
+7. stop the domain and the test
+
+# Developing new tests
+
+A Nitro test code is composed the following steps
+1. configure the CDROM to be injected
+2. define the nitro callbacks
+3. run Nitro and get the events
+4. analyze the events and validate the test
+
+Test code example
+~~~Python
+def test_01(self):
+    # 1. configure the cdrom
+    # a custom binary
+    self.vm.cdrom.set_executable('binary_path')
+    # a batch script
+    script = 'dir C:\\windows\\system32'
+    self.vm.cdrom.set_script(script)
+    # a powershell script
+    script = 'Get-ChildItem -Path C:\\windows\\system32'
+    self.vm.cdrom.set_script(script, powershell=True)
+    
+    # 2. define your Nitro callbacks
+    def enter_NtOpenFile(syscall):
+        logging.info('enter in NtOpenFile')
+        syscall.hook = 'foobar'
+        
+    hooks = {
+        'NtOpenFile': enter_NtOpenFile,
+    }
+    
+    # 3. run the test and get the events
+    # This will start Nitro in the background and wait for the test to be executed
+    events, exec_time = self.vm.run_test(hooks=hooks)
+    
+    # optional: log nitro events
+    logging.debug('Writing events...')
+    with open('events.json', 'w') as f:
+        json.dump(events, f, indent=4)
+        
+    # 4. analyze events and validate
+    event_found = [e for e in events if e.get('hook') and e['hook'] == "foobar"]
+    self.assertTrue(event_found)
+~~~
+
+## Controlling Nitro loop in the test
+
+If you want to directly control the nitro loop by yourself, here is how to do it.
+
+~~~Python
+def test_loop(self):
+    script = 'Get-ChildItem -Path C:\\windows\\system32'
+    self.vm.cdrom.set_script(script, powershell=True)
+
+    events = []
+    with Backend(self.domain, True) as backend:
+        backend.nitro.set_traps(True)
+        stop_event = self.vm.run_test(wait=False)
+        for event in backend.nitro.listen():
+            syscall = backend.process_event(event)
+            
+            if syscall.name == "NtOpenFile":
+                logging.info('NtOpenFile')
+            
+            events.append(syscall.info())
+
+            if stop_event.is_set():
+                break
+~~~

--- a/tests/cdrom.py
+++ b/tests/cdrom.py
@@ -1,0 +1,101 @@
+import os
+import stat
+import shutil
+import logging
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory, NamedTemporaryFile
+
+
+class CDROM:
+
+    def __init__(self):
+        # create cdrom dir
+        self.cdrom_dir_tmp = TemporaryDirectory()
+        self.tmp_dir = TemporaryDirectory()
+        # give qemu permission to execute and read in this directory
+        os.chmod(self.tmp_dir.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                                    stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH)
+        self.cdrom_dir = self.cdrom_dir_tmp.name
+        self.cdrom_iso_tmp = None
+        # write autorun.inf
+        self.write_autorun()
+        # write main script
+        self.write_run_bat()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.cleanup()
+
+    def cleanup(self):
+        self.cdrom_iso_tmp.close()
+        self.tmp_dir.cleanup()
+        self.cdrom_dir_tmp.cleanup()
+
+    def write_autorun(self):
+        # write autorun.inf
+        content = """
+[autorun]
+open=run.bat
+"""[1:].replace('\n', '\r\n')
+        autorun_path = os.path.join(self.cdrom_dir, 'autorun.inf')
+        with open(autorun_path, 'w') as f:
+            f.write(content)
+
+    def write_run_bat(self):
+        # write autorun.inf
+        content = """
+CALL test.bat
+sc stop winrm
+"""[1:].replace('\n', '\r\n')
+        run_bat_path = os.path.join(self.cdrom_dir, 'run.bat')
+        with open(run_bat_path, 'w') as f:
+            f.write(content)
+
+    def set_script(self, script, powershell=False):
+        script = script.replace('\n', '\r\n')
+        if powershell:
+            test_bat_content = 'powershell -File test.ps1'
+            # write test.ps1
+            test_ps1_path = os.path.join(self.cdrom_dir, 'test.ps1')
+            with open(test_ps1_path, 'w') as f:
+                f.write(script)
+        else:
+            test_bat_content = script
+        test_bat_path = os.path.join(self.cdrom_dir, 'test.bat')
+        with open(test_bat_path, 'w') as f:
+            f.write(test_bat_content)
+
+    def set_executable(self, exe_path):
+        exe_path = Path(exe_path)
+        # copy executable
+        exe_path_cdrom = os.path.join(self.cdrom_dir, exe_path.name)
+        shutil.copyfile(str(exe_path), exe_path_cdrom)
+        # write test.bat
+        content = """
+{}
+""".format(exe_path.name)[1:].replace('\n', '\r\n')
+        test_bat_path = os.path.join(self.cdrom_dir, 'test.bat')
+        with open(test_bat_path, 'w') as f:
+            f.write(content)
+
+    def generate_iso(self, cleanup=True):
+        self.cdrom_iso_tmp = NamedTemporaryFile(delete=False, dir=self.tmp_dir.name)
+        cdrom_iso = self.cdrom_iso_tmp.name
+        # chmod to be r/w by everyone
+        # so we can remove the file even when qemu takes the ownership
+
+        # generate iso
+        genisoimage_bin = shutil.which('genisoimage')
+        if genisoimage_bin is None:
+            raise Exception('Cannot find genisoimage executable')
+        args = [genisoimage_bin, '-o', cdrom_iso, '-iso-level', '4', self.cdrom_dir]
+        subprocess.check_call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        logging.debug('ISO generated at {}'.format(cdrom_iso))
+        # cleanup
+        if cleanup:
+            self.cdrom_dir_tmp.cleanup()
+        return cdrom_iso
+

--- a/tests/cdrom.py
+++ b/tests/cdrom.py
@@ -13,6 +13,7 @@ class CDROM:
         # create cdrom dir
         self.cdrom_dir_tmp = TemporaryDirectory()
         self.tmp_dir = TemporaryDirectory()
+        self.cdrom_iso_tmp = None
         # give qemu permission to execute and read in this directory
         os.chmod(self.tmp_dir.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
                                     stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH)
@@ -30,7 +31,8 @@ class CDROM:
         self.cleanup()
 
     def cleanup(self):
-        self.cdrom_iso_tmp.close()
+        if self.cdrom_dir_tmp:
+            self.cdrom_iso_tmp.close()
         self.tmp_dir.cleanup()
         self.cdrom_dir_tmp.cleanup()
 

--- a/tests/layers.py
+++ b/tests/layers.py
@@ -1,0 +1,48 @@
+import os
+import logging
+import shutil
+import datetime
+import libvirt
+
+from vmtest_helper import VMTestHelper
+from cdrom import CDROM
+
+
+class LoggingLayer(object):
+
+    @classmethod
+    def testSetUp(cls, test_class):
+        # clean old test directory
+        test_dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), test_class._testMethodName)
+        shutil.rmtree(test_dir_path, ignore_errors=True)
+        os.makedirs(test_dir_path, exist_ok=True)
+        test_class.script_dir = os.path.dirname(os.path.realpath(__file__))
+        # chdir into this directory for the test
+        test_class.origin_wd = os.getcwd()
+        os.chdir(test_dir_path)
+        # create logging file handler
+        test_class.f_handler = logging.FileHandler('test.log', mode='w')
+        logging.getLogger().addHandler(test_class.f_handler)
+        logging.info('Starting test at {}'.format(datetime.datetime.now()))
+
+    @classmethod
+    def testTearDown(cls, test_class):
+        # chdir back to original wd
+        os.chdir(test_class.origin_wd)
+        # remove file handler
+        logging.info('Ending test at {}'.format(datetime.datetime.now()))
+        logging.getLogger().removeHandler(test_class.f_handler)
+
+
+class VMLayer(LoggingLayer):
+
+    @classmethod
+    def testSetUp(cls, test_class):
+        con = libvirt.open('qemu:///system')
+        test_class.domain = con.lookupByName('nitro_win7x64')
+        test_class.vm = VMTestHelper(test_class.domain)
+
+
+    @classmethod
+    def testTearDown(cls, test_class):
+        test_class.vm.stop()

--- a/tests/test_nitro.py
+++ b/tests/test_nitro.py
@@ -3,18 +3,13 @@
 # stdlib
 import os
 import sys
-import re
-import stat
 import logging
-import subprocess
 import shutil
 import time
 import xml.etree.ElementTree as tree
 import json
 from threading import Thread, Event
 import socket
-from tempfile import TemporaryDirectory, NamedTemporaryFile
-from pathlib import Path
 import datetime
 import unittest
 
@@ -23,9 +18,9 @@ import libvirt
 
 # local
 sys.path.insert(1, os.path.join(sys.path[0], '..'))
-from nitro.nitro import Nitro
 from nitro.backend import Backend
 from nitro.win_types import ObjectAttributes, FileAccessMask
+from tests.cdrom import CDROM
 
 SNAPSHOT_BASE = 'base'
 
@@ -41,98 +36,6 @@ def wait_winrm(ip_addr, opened=True):
             break
         time.sleep(1)
 
-
-class CDROM:
-
-    def __init__(self):
-        # create cdrom dir
-        self.cdrom_dir_tmp = TemporaryDirectory()
-        self.tmp_dir = TemporaryDirectory()
-        # give qemu permission to execute and read in this directory
-        os.chmod(self.tmp_dir.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
-                                    stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH)
-        self.cdrom_dir = self.cdrom_dir_tmp.name
-        self.cdrom_iso_tmp = None
-        # write autorun.inf
-        self.write_autorun()
-        # write main script
-        self.write_run_bat()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        self.cleanup()
-
-    def cleanup(self):
-        self.cdrom_iso_tmp.close()
-        self.tmp_dir.cleanup()
-        self.cdrom_dir_tmp.cleanup()
-
-    def write_autorun(self):
-        # write autorun.inf
-        content = """
-[autorun]
-open=run.bat
-"""[1:].replace('\n', '\r\n')
-        autorun_path = os.path.join(self.cdrom_dir, 'autorun.inf')
-        with open(autorun_path, 'w') as f:
-            f.write(content)
-
-    def write_run_bat(self):
-        # write autorun.inf
-        content = """
-CALL test.bat
-sc stop winrm
-"""[1:].replace('\n', '\r\n')
-        run_bat_path = os.path.join(self.cdrom_dir, 'run.bat')
-        with open(run_bat_path, 'w') as f:
-            f.write(content)
-
-    def set_script(self, script, powershell=False):
-        script = script.replace('\n', '\r\n')
-        if powershell:
-            test_bat_content = 'powershell -File test.ps1'
-            # write test.ps1
-            test_ps1_path = os.path.join(self.cdrom_dir, 'test.ps1')
-            with open(test_ps1_path, 'w') as f:
-                f.write(script)
-        else:
-            test_bat_content = script
-        test_bat_path = os.path.join(self.cdrom_dir, 'test.bat')
-        with open(test_bat_path, 'w') as f:
-            f.write(test_bat_content)
-
-    def set_executable(self, exe_path):
-        exe_path = Path(exe_path)
-        # copy executable
-        exe_path_cdrom = os.path.join(self.cdrom_dir, exe_path.name)
-        shutil.copyfile(str(exe_path), exe_path_cdrom)
-        # write test.bat
-        content = """
-{}
-""".format(exe_path.name)[1:].replace('\n', '\r\n')
-        test_bat_path = os.path.join(self.cdrom_dir, 'test.bat')
-        with open(test_bat_path, 'w') as f:
-            f.write(content)
-
-    def generate_iso(self, cleanup=True):
-        self.cdrom_iso_tmp = NamedTemporaryFile(delete=False, dir=self.tmp_dir.name)
-        cdrom_iso = self.cdrom_iso_tmp.name
-        # chmod to be r/w by everyone
-        # so we can remove the file even when qemu takes the ownership
-
-        # generate iso
-        genisoimage_bin = shutil.which('genisoimage')
-        if genisoimage_bin is None:
-            raise Exception('Cannot find genisoimage executable')
-        args = [genisoimage_bin, '-o', cdrom_iso, '-iso-level', '4', self.cdrom_dir]
-        subprocess.check_call(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        logging.debug('ISO generated at {}'.format(cdrom_iso))
-        # cleanup
-        if cleanup:
-            self.cdrom_dir_tmp.cleanup()
-        return cdrom_iso
 
 
 class VMTest:

--- a/tests/test_nitro.py
+++ b/tests/test_nitro.py
@@ -2,158 +2,19 @@
 
 # stdlib
 import os
-import sys
 import logging
 import shutil
-import time
-import xml.etree.ElementTree as tree
 import json
-from threading import Thread, Event
-import socket
 import datetime
 import unittest
 
 # 3rd
 import libvirt
 
-# local
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
-from nitro.backend import Backend
+
 from nitro.win_types import ObjectAttributes, FileAccessMask
 from tests.cdrom import CDROM
-
-SNAPSHOT_BASE = 'base'
-
-
-def wait_winrm(ip_addr, opened=True):
-    while True:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        state = s.connect_ex((ip_addr, 5985))
-        if state == 0 and opened:
-            break
-        elif state != 0 and not opened:
-            # received a RST, port is closed
-            break
-        time.sleep(1)
-
-
-
-class VMTest:
-
-    def __init__(self, domain):
-        # looking for a nitro_<vm> in qemu:///system
-        self.domain = domain
-        # revert to base snapshot if present
-        try:
-            snap = self.domain.snapshotLookupByName(SNAPSHOT_BASE)
-            logging.info('Reverting to base snapshot')
-            self.domain.revertToSnapshot(snap)
-        except libvirt.libvirtError:
-            logging.warning('Missing snapshot "{}"'.format(SNAPSHOT_BASE))
-
-
-    def wait_for_ip(self, network_name='default'):
-        # find MAC address
-        dom_elem = tree.fromstring(self.domain.XMLDesc())
-        mac_addr = dom_elem.find("./devices/interface[@type='network']/mac").get('address')
-        logging.debug('MAC address : {}'.format(mac_addr))
-        while True:
-            net = self.domain.connect().networkLookupByName(network_name)
-            leases = net.DHCPLeases()
-            found = [l for l in leases if l['mac'] == mac_addr]
-            if found:
-                return found[0]['ipaddr']
-            time.sleep(1)
-
-    def mount_cdrom(self, cdrom_path):
-        logging.info('Mounting CDROM image')
-        dom_elem = tree.fromstring(self.domain.XMLDesc())
-        # find cdrom
-        cdrom_elem = dom_elem.find("./devices/disk[@device='cdrom']")
-        # find source
-        source_elem = cdrom_elem.find('./source')
-        if source_elem is None:
-            tree.SubElement(cdrom_elem, 'source')
-            source_elem = cdrom_elem.find('./source')
-        source_elem.set('file', cdrom_path)
-        new_xml = tree.tostring(cdrom_elem).decode('utf-8')
-        self.domain.updateDeviceFlags(new_xml, libvirt.VIR_DOMAIN_AFFECT_LIVE)
-
-    def run(self, cdrom_iso, analyze=True, idle=False, hooks=None):
-        # start domain
-        logging.info('Testing {}'.format(self.domain.name()))
-        self.domain.create()
-        # wait for IP address
-        ip = self.wait_for_ip()
-        logging.info('IP address : {}'.format(ip))
-        # wait for WinRM to be available
-        wait_winrm(ip, True)
-        if idle:
-            # wait for idle
-            idle_wait = 60 * 5
-            logging.info('Waiting for Windows to be idle (5 min)')
-            time.sleep(idle_wait)
-        # run nitro before inserting CDROM
-        nitro = NitroThread(self.domain, analyze, hooks)
-        nitro.start()
-        # mount cdrom, test is executed
-        self.mount_cdrom(cdrom_iso)
-        # test is executing under Nitro monitoring
-        # wait on WinRM to be closed
-        wait_winrm(ip, False)
-        # # wait for nitro thread to terminate properly
-        nitro.stop()
-        self.domain.shutdown()
-        # stop domain
-        while self.domain.state()[0] != libvirt.VIR_DOMAIN_SHUTOFF:
-            time.sleep(1)
-        result = (nitro.events, nitro.total_time)
-        return result
-
-    def force_shutdown(self):
-        if self.domain.isActive():
-            logging.info('Force VM shutdown, the test probably failed')
-            self.domain.destroy()
-
-
-class NitroThread(Thread):
-
-    def __init__(self, domain, analyze=False, hooks=None):
-        super().__init__()
-        self.domain = domain
-        self.analyze_enabled = analyze
-        self.backend = Backend(self.domain, analyze)
-        self.setup_hooks(hooks)
-        self.stop_request = Event()
-        self.total_time = None
-        self.events = []
-
-    def setup_hooks(self, hooks):
-        if hooks:
-            for name, callback in hooks.items():
-                self.backend.define_hook(name, callback)
-
-    def run(self):
-        # start timer
-        start_time = datetime.datetime.now()
-        self.backend.nitro.set_traps(True)
-        for event in self.backend.nitro.listen():
-            if self.analyze_enabled:
-                syscall = self.backend.process_event(event)
-                ev_info = syscall.info()
-            else:
-                ev_info = event.info()
-            self.events.append(ev_info)
-            if self.stop_request.isSet():
-                break
-        self.backend.stop()
-        # stop timer
-        stop_time = datetime.datetime.now()
-        self.total_time = str(stop_time - start_time)
-
-    def stop(self):
-        self.stop_request.set()
-        self.join()
+from tests.vmtest_helper import VMTestHelper
 
 
 class TestNitro(unittest.TestCase):
@@ -161,7 +22,7 @@ class TestNitro(unittest.TestCase):
     def setUp(self):
         con = libvirt.open('qemu:///system')
         domain = con.lookupByName('nitro_win7x64')
-        self.vm_test = VMTest(domain)
+        self.vm_test = VMTestHelper(domain)
         self.cdrom = CDROM()
         # clean old test directory
         test_dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), self._testMethodName)

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,101 +1,21 @@
-#!/usr/bin/env python3
-
-# stdlib
 import os
-import logging
-import shutil
-import json
-import datetime
+import sys
 import unittest
+import logging
+import json
+from layers import VMLayer
 
-# 3rd
-import libvirt
-
-
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
 from nitro.win_types import ObjectAttributes, FileAccessMask
-from tests.cdrom import CDROM
-from tests.vmtest_helper import VMTestHelper
+from nitro.backend import Backend
 
-
-class TestNitro(unittest.TestCase):
-
-    def setUp(self):
-        con = libvirt.open('qemu:///system')
-        domain = con.lookupByName('nitro_win7x64')
-        self.vm_test = VMTestHelper(domain)
-        self.cdrom = CDROM()
-        # clean old test directory
-        test_dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), self._testMethodName)
-        shutil.rmtree(test_dir_path, ignore_errors=True)
-        os.makedirs(test_dir_path, exist_ok=True)
-        self.script_dir = os.path.dirname(os.path.realpath(__file__))
-        # chdir into this directory for the test
-        self.origin_wd = os.getcwd()
-        os.chdir(test_dir_path)
-        # create logging file handler
-        self.f_handler = logging.FileHandler('test.log', mode='w')
-        logging.getLogger().addHandler(self.f_handler)
-        logging.info('Starting test at {}'.format(datetime.datetime.now()))
-
-    def tearDown(self):
-        self.cdrom.cleanup()
-        # chdir back to original wd
-        os.chdir(self.origin_wd)
-        # force VM to stop if still running
-        self.vm_test.force_shutdown()
-        # remove file handler
-        logging.info('Ending test at {}'.format(datetime.datetime.now()))
-        logging.getLogger().removeHandler(self.f_handler)
-
-    def test_list_system32_no_analyze(self):
-        script = 'Get-ChildItem -Path C:\\windows\\system32'
-        self.cdrom.set_script(script, powershell=True)
-        cdrom_iso = self.cdrom.generate_iso()
-        events, exec_time = self.vm_test.run(cdrom_iso, analyze=False)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
-
-    def test_list_windows_no_analyze(self):
-        script = 'Get-ChildItem -Path C:\\windows'
-        self.cdrom.set_script(script, powershell=True)
-        cdrom_iso = self.cdrom.generate_iso()
-        events, exec_time = self.vm_test.run(cdrom_iso, analyze=False)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
-
-    def test_list_system32_analyze(self):
-        script = 'Get-ChildItem -Path C:\\windows\\system32'
-        self.cdrom.set_script(script, powershell=True)
-        cdrom_iso = self.cdrom.generate_iso()
-        events, exec_time = self.vm_test.run(cdrom_iso)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
-
-    def test_list_windows_analyze(self):
-        script = 'Get-ChildItem -Path C:\\windows'
-        self.cdrom.set_script(script, powershell=True)
-        cdrom_iso = self.cdrom.generate_iso()
-        events, exec_time = self.vm_test.run(cdrom_iso)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
+class TestWindows(unittest.TestCase):
+    layer = VMLayer
 
     def test_hook_openfile(self):
         file_path = 'C:\\Program Files\\Windows Sidebar\\Gadgets\\PicturePuzzle.Gadget\\en-US\\gadget.xml'
         script = 'Get-Content \"{}\"'.format(file_path)
-        self.cdrom.set_script(script, powershell=True)
-        cdrom_iso = self.cdrom.generate_iso()
+        self.vm.cdrom.set_script(script, powershell=True)
 
         def enter_NtOpenFile(syscall):
             KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
@@ -121,7 +41,7 @@ class TestNitro(unittest.TestCase):
             'NtOpenFile': enter_NtOpenFile,
             'NtCreateFile': enter_NtCreateFile,
         }
-        events, exec_time = self.vm_test.run(cdrom_iso, hooks=hooks)
+        events, exec_time = self.vm.run_test_test(hooks=hooks)
         # writing events
         logging.debug('Writing events...')
         with open('events.json', 'w') as f:
@@ -134,292 +54,10 @@ class TestNitro(unittest.TestCase):
         opened_files = [e['hook']['object_name'] for e in events if e.get('hook')]
         logging.info('opened_files {}'.format(json.dumps(opened_files, indent=4)))
 
-    def test_createfile_read(self):
-        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_read.exe')
-        self.cdrom.set_executable(binary_path)
-        cdrom_iso = self.cdrom.generate_iso()
-
-        def enter_NtCreateFile(syscall):
-            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
-            obj = ObjectAttributes(object_attributes, syscall.process)
-            buffer = obj.ObjectName.Buffer
-            access = FileAccessMask(DesiredAccess)
-            syscall.hook = {
-                'object_name': buffer,
-                'access': access.rights
-            }
-
-        hooks = {
-            'NtCreateFile': enter_NtCreateFile,
-        }
-        events, exec_time = self.vm_test.run(cdrom_iso, hooks=hooks)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
-        # checking if we find the event where the file is opened
-        event_found = [e for e in events if e.get('hook')
-                       and e['hook']['object_name'].find('foobar.txt') != -1
-                       and 'GENERIC_READ' in e['hook']['access']]
-        self.assertTrue(event_found)
-
-    def test_createfile_write(self):
-        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_write.exe')
-        self.cdrom.set_executable(binary_path)
-        cdrom_iso = self.cdrom.generate_iso()
-
-        def enter_NtCreateFile(syscall):
-            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
-            obj = ObjectAttributes(object_attributes, syscall.process)
-            buffer = obj.ObjectName.Buffer
-            access = FileAccessMask(DesiredAccess)
-            syscall.hook = {
-                'object_name': buffer,
-                'access': access.rights
-            }
-
-        hooks = {
-            'NtCreateFile': enter_NtCreateFile,
-        }
-        events, exec_time = self.vm_test.run(cdrom_iso, hooks=hooks)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
-        # checking if we find the event where the file is opened
-        event_found = [e for e in events if e.get('hook')
-                       and e['hook']['object_name'].find('foobar.txt') != -1
-                       and 'GENERIC_WRITE' in e['hook']['access']]
-        self.assertTrue(event_found)
-
-    def test_createfile_execute(self):
-        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_execute.exe')
-        self.cdrom.set_executable(binary_path)
-        cdrom_iso = self.cdrom.generate_iso()
-
-        def enter_NtCreateFile(syscall):
-            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
-            obj = ObjectAttributes(object_attributes, syscall.process)
-            buffer = obj.ObjectName.Buffer
-            access = FileAccessMask(DesiredAccess)
-            syscall.hook = {
-                'object_name': buffer,
-                'access': access.rights
-            }
-
-        hooks = {
-            'NtCreateFile': enter_NtCreateFile,
-        }
-        events, exec_time = self.vm_test.run(cdrom_iso, hooks=hooks)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
-        # checking if we find the event where the file is opened
-        event_found = [e for e in events if e.get('hook')
-                       and e['hook']['object_name'].find('foobar.txt') != -1
-                       and 'GENERIC_EXECUTE' in e['hook']['access']]
-        self.assertTrue(event_found)
-
-    def test_createfile_all(self):
-        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_all.exe')
-        self.cdrom.set_executable(binary_path)
-        cdrom_iso = self.cdrom.generate_iso()
-
-        def enter_NtCreateFile(syscall):
-            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
-            obj = ObjectAttributes(object_attributes, syscall.process)
-            buffer = obj.ObjectName.Buffer
-            access = FileAccessMask(DesiredAccess)
-            syscall.hook = {
-                'object_name': buffer,
-                'access': access.rights
-            }
-
-        hooks = {
-            'NtCreateFile': enter_NtCreateFile,
-        }
-        events, exec_time = self.vm_test.run(cdrom_iso, hooks=hooks)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
-        # checking if we find the event where the file is opened
-        event_found = [e for e in events if e.get('hook')
-                       and e['hook']['object_name'].find('foobar.txt') != -1
-                       and 'GENERIC_ALL' in e['hook']['access']]
-        self.assertTrue(event_found)
-
-    def test_createfile_append(self):
-        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_append.exe')
-        self.cdrom.set_executable(binary_path)
-        cdrom_iso = self.cdrom.generate_iso()
-
-        def enter_NtCreateFile(syscall):
-            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
-            obj = ObjectAttributes(object_attributes, syscall.process)
-            buffer = obj.ObjectName.Buffer
-            access = FileAccessMask(DesiredAccess)
-            syscall.hook = {
-                'object_name': buffer,
-                'access': access.rights
-            }
-
-        hooks = {
-            'NtCreateFile': enter_NtCreateFile,
-        }
-        events, exec_time = self.vm_test.run(cdrom_iso, hooks=hooks)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
-        # checking if we find the event where the file is opened
-        event_found = [e for e in events if e.get('hook')
-                       and e['hook']['object_name'].find('foobar.txt') != -1
-                       and 'FILE_APPEND_DATA' in e['hook']['access']]
-        self.assertTrue(event_found)
-
-    def test_createfile_file_execute(self):
-        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_file_execute.exe')
-        self.cdrom.set_executable(binary_path)
-        cdrom_iso = self.cdrom.generate_iso()
-
-        def enter_NtCreateFile(syscall):
-            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
-            obj = ObjectAttributes(object_attributes, syscall.process)
-            buffer = obj.ObjectName.Buffer
-            access = FileAccessMask(DesiredAccess)
-            syscall.hook = {
-                'object_name': buffer,
-                'access': access.rights
-            }
-
-        hooks = {
-            'NtCreateFile': enter_NtCreateFile,
-        }
-        events, exec_time = self.vm_test.run(cdrom_iso, hooks=hooks)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
-        # checking if we find the event where the file is opened
-        event_found = [e for e in events if e.get('hook')
-                       and e['hook']['object_name'].find('foobar.txt') != -1
-                       and 'FILE_EXECUTE' in e['hook']['access']]
-        self.assertTrue(event_found)
-
-    def test_createfile_read_data(self):
-        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_read_data.exe')
-        self.cdrom.set_executable(binary_path)
-        cdrom_iso = self.cdrom.generate_iso()
-
-        def enter_NtCreateFile(syscall):
-            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
-            obj = ObjectAttributes(object_attributes, syscall.process)
-            buffer = obj.ObjectName.Buffer
-            access = FileAccessMask(DesiredAccess)
-            syscall.hook = {
-                'object_name': buffer,
-                'access': access.rights
-            }
-
-        hooks = {
-            'NtCreateFile': enter_NtCreateFile,
-        }
-        events, exec_time = self.vm_test.run(cdrom_iso, hooks=hooks)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
-        # checking if we find the event where the file is opened
-        event_found = [e for e in events if e.get('hook')
-                       and e['hook']['object_name'].find('foobar.txt') != -1
-                       and 'FILE_READ_DATA' in e['hook']['access']]
-        self.assertTrue(event_found)
-
-    def test_createfile_write_data(self):
-        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_write_data.exe')
-        self.cdrom.set_executable(binary_path)
-        cdrom_iso = self.cdrom.generate_iso()
-
-        def enter_NtCreateFile(syscall):
-            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
-            obj = ObjectAttributes(object_attributes, syscall.process)
-            buffer = obj.ObjectName.Buffer
-            access = FileAccessMask(DesiredAccess)
-            syscall.hook = {
-                'object_name': buffer,
-                'access': access.rights
-            }
-
-        hooks = {
-            'NtCreateFile': enter_NtCreateFile,
-        }
-        events, exec_time = self.vm_test.run(cdrom_iso, hooks=hooks)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
-        # checking if we find the event where the file is opened
-        event_found = [e for e in events if e.get('hook')
-                       and e['hook']['object_name'].find('foobar.txt') != -1
-                       and 'FILE_WRITE_DATA' in e['hook']['access']]
-        self.assertTrue(event_found)
-
-    def test_deletefile(self):
-        binary_path = os.path.join(self.script_dir, 'binaries', 'delete_file.exe')
-        self.cdrom.set_executable(binary_path)
-        cdrom_iso = self.cdrom.generate_iso()
-
-        def enter_NtOpenFile(syscall):
-            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
-            obj = ObjectAttributes(object_attributes, syscall.process)
-            buffer = obj.ObjectName.Buffer
-            access = FileAccessMask(DesiredAccess)
-            syscall.hook = {
-                'object_name': buffer,
-                'access': access.rights
-            }
-
-        def enter_NtCreateFile(syscall):
-            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
-            obj = ObjectAttributes(object_attributes, syscall.process)
-            buffer = obj.ObjectName.Buffer
-            access = FileAccessMask(DesiredAccess)
-            syscall.hook = {
-                'object_name': buffer,
-                'access': access.rights
-            }
-
-        hooks = {
-            'NtOpenFile': enter_NtOpenFile,
-            'NtCreateFile': enter_NtCreateFile,
-        }
-        events, exec_time = self.vm_test.run(cdrom_iso, hooks=hooks)
-        # writing events
-        logging.debug('Writing events...')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
-        logging.info('Test execution time {}'.format(exec_time))
-        # checking if we find the event where the file is opened
-        event_found = [e for e in events if e.get('hook')
-                       and e['hook']['object_name'].find('foobar.txt') != -1
-                       and 'DELETE' in e['hook']['access']]
-        self.assertTrue(event_found)
-
     def test_hook_openkey(self):
         key_path = 'Software\\ABCDMagicKey1234'
         script = 'New-Item \"HKCU:\\{}\" -Force | New-ItemProperty -Name foobar -Value true -PropertyType STRING -Force'.format(key_path)
-        self.cdrom.set_script(script, powershell=True)
-        cdrom_iso = self.cdrom.generate_iso()
+        self.vm.cdrom.set_script(script, powershell=True)
 
         def enter_NtOpenKey(syscall):
             KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
@@ -437,7 +75,7 @@ class TestNitro(unittest.TestCase):
             'NtOpenKey': enter_NtOpenKey,
             'NtCreateKey': enter_NtCreateKey,
         }
-        events, exec_time = self.vm_test.run(cdrom_iso, hooks=hooks)
+        events, exec_time = self.vm.run_test(hooks=hooks)
         # writing events
         logging.debug('Writing events...')
         with open('events.json', 'w') as f:
@@ -445,4 +83,276 @@ class TestNitro(unittest.TestCase):
         logging.info('Test execution time {}'.format(exec_time))
         # checking if we find the event where the file is opened
         event_found = [e for e in events if e.get('hook') and e['hook'].find(key_path) != -1]
+        self.assertTrue(event_found)
+
+    def test_createfile_read(self):
+        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_read.exe')
+        self.vm.cdrom.set_executable(binary_path)
+
+        def enter_NtCreateFile(syscall):
+            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
+            obj = ObjectAttributes(object_attributes, syscall.process)
+            buffer = obj.ObjectName.Buffer
+            access = FileAccessMask(DesiredAccess)
+            syscall.hook = {
+                'object_name': buffer,
+                'access': access.rights
+            }
+
+        hooks = {
+            'NtCreateFile': enter_NtCreateFile,
+        }
+        events, exec_time = self.vm.run_test(hooks=hooks)
+        # writing events
+        logging.debug('Writing events...')
+        with open('events.json', 'w') as f:
+            json.dump(events, f, indent=4)
+        logging.info('Test execution time {}'.format(exec_time))
+        # checking if we find the event where the file is opened
+        event_found = [e for e in events if e.get('hook')
+                       and e['hook']['object_name'].find('foobar.txt') != -1
+                       and 'GENERIC_READ' in e['hook']['access']]
+        self.assertTrue(event_found)
+
+    def test_createfile_write(self):
+        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_write.exe')
+        self.vm.cdrom.set_executable(binary_path)
+
+        def enter_NtCreateFile(syscall):
+            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
+            obj = ObjectAttributes(object_attributes, syscall.process)
+            buffer = obj.ObjectName.Buffer
+            access = FileAccessMask(DesiredAccess)
+            syscall.hook = {
+                'object_name': buffer,
+                'access': access.rights
+            }
+
+        hooks = {
+            'NtCreateFile': enter_NtCreateFile,
+        }
+        events, exec_time = self.vm.run_test(hooks=hooks)
+        # writing events
+        logging.debug('Writing events...')
+        with open('events.json', 'w') as f:
+            json.dump(events, f, indent=4)
+        logging.info('Test execution time {}'.format(exec_time))
+        # checking if we find the event where the file is opened
+        event_found = [e for e in events if e.get('hook')
+                       and e['hook']['object_name'].find('foobar.txt') != -1
+                       and 'GENERIC_WRITE' in e['hook']['access']]
+        self.assertTrue(event_found)
+
+    def test_createfile_execute(self):
+        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_execute.exe')
+        self.vm.cdrom.set_executable(binary_path)
+
+        def enter_NtCreateFile(syscall):
+            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
+            obj = ObjectAttributes(object_attributes, syscall.process)
+            buffer = obj.ObjectName.Buffer
+            access = FileAccessMask(DesiredAccess)
+            syscall.hook = {
+                'object_name': buffer,
+                'access': access.rights
+            }
+
+        hooks = {
+            'NtCreateFile': enter_NtCreateFile,
+        }
+        events, exec_time = self.vm.run_test(hooks=hooks)
+        # writing events
+        logging.debug('Writing events...')
+        with open('events.json', 'w') as f:
+            json.dump(events, f, indent=4)
+        logging.info('Test execution time {}'.format(exec_time))
+        # checking if we find the event where the file is opened
+        event_found = [e for e in events if e.get('hook')
+                       and e['hook']['object_name'].find('foobar.txt') != -1
+                       and 'GENERIC_EXECUTE' in e['hook']['access']]
+        self.assertTrue(event_found)
+
+    def test_createfile_all(self):
+        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_all.exe')
+        self.vm.cdrom.set_executable(binary_path)
+
+        def enter_NtCreateFile(syscall):
+            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
+            obj = ObjectAttributes(object_attributes, syscall.process)
+            buffer = obj.ObjectName.Buffer
+            access = FileAccessMask(DesiredAccess)
+            syscall.hook = {
+                'object_name': buffer,
+                'access': access.rights
+            }
+
+        hooks = {
+            'NtCreateFile': enter_NtCreateFile,
+        }
+        events, exec_time = self.vm.run_test(hooks=hooks)
+        # writing events
+        logging.debug('Writing events...')
+        with open('events.json', 'w') as f:
+            json.dump(events, f, indent=4)
+        logging.info('Test execution time {}'.format(exec_time))
+        # checking if we find the event where the file is opened
+        event_found = [e for e in events if e.get('hook')
+                       and e['hook']['object_name'].find('foobar.txt') != -1
+                       and 'GENERIC_ALL' in e['hook']['access']]
+        self.assertTrue(event_found)
+
+    def test_createfile_append(self):
+        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_append.exe')
+        self.vm.cdrom.set_executable(binary_path)
+
+        def enter_NtCreateFile(syscall):
+            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
+            obj = ObjectAttributes(object_attributes, syscall.process)
+            buffer = obj.ObjectName.Buffer
+            access = FileAccessMask(DesiredAccess)
+            syscall.hook = {
+                'object_name': buffer,
+                'access': access.rights
+            }
+
+        hooks = {
+            'NtCreateFile': enter_NtCreateFile,
+        }
+        events, exec_time = self.vm.run_test(hooks=hooks)
+        # writing events
+        logging.debug('Writing events...')
+        with open('events.json', 'w') as f:
+            json.dump(events, f, indent=4)
+        logging.info('Test execution time {}'.format(exec_time))
+        # checking if we find the event where the file is opened
+        event_found = [e for e in events if e.get('hook')
+                       and e['hook']['object_name'].find('foobar.txt') != -1
+                       and 'FILE_APPEND_DATA' in e['hook']['access']]
+        self.assertTrue(event_found)
+
+    def test_createfile_file_execute(self):
+        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_file_execute.exe')
+        self.vm.cdrom.set_executable(binary_path)
+
+        def enter_NtCreateFile(syscall):
+            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
+            obj = ObjectAttributes(object_attributes, syscall.process)
+            buffer = obj.ObjectName.Buffer
+            access = FileAccessMask(DesiredAccess)
+            syscall.hook = {
+                'object_name': buffer,
+                'access': access.rights
+            }
+
+        hooks = {
+            'NtCreateFile': enter_NtCreateFile,
+        }
+        events, exec_time = self.vm.run_test(hooks=hooks)
+        # writing events
+        logging.debug('Writing events...')
+        with open('events.json', 'w') as f:
+            json.dump(events, f, indent=4)
+        logging.info('Test execution time {}'.format(exec_time))
+        # checking if we find the event where the file is opened
+        event_found = [e for e in events if e.get('hook')
+                       and e['hook']['object_name'].find('foobar.txt') != -1
+                       and 'FILE_EXECUTE' in e['hook']['access']]
+        self.assertTrue(event_found)
+
+    def test_createfile_read_data(self):
+        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_read_data.exe')
+        self.vm.cdrom.set_executable(binary_path)
+
+        def enter_NtCreateFile(syscall):
+            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
+            obj = ObjectAttributes(object_attributes, syscall.process)
+            buffer = obj.ObjectName.Buffer
+            access = FileAccessMask(DesiredAccess)
+            syscall.hook = {
+                'object_name': buffer,
+                'access': access.rights
+            }
+
+        hooks = {
+            'NtCreateFile': enter_NtCreateFile,
+        }
+        events, exec_time = self.vm.run_test(hooks=hooks)
+        # writing events
+        logging.debug('Writing events...')
+        with open('events.json', 'w') as f:
+            json.dump(events, f, indent=4)
+        logging.info('Test execution time {}'.format(exec_time))
+        # checking if we find the event where the file is opened
+        event_found = [e for e in events if e.get('hook')
+                       and e['hook']['object_name'].find('foobar.txt') != -1
+                       and 'FILE_READ_DATA' in e['hook']['access']]
+        self.assertTrue(event_found)
+
+    def test_createfile_write_data(self):
+        binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_write_data.exe')
+        self.vm.cdrom.set_executable(binary_path)
+
+        def enter_NtCreateFile(syscall):
+            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
+            obj = ObjectAttributes(object_attributes, syscall.process)
+            buffer = obj.ObjectName.Buffer
+            access = FileAccessMask(DesiredAccess)
+            syscall.hook = {
+                'object_name': buffer,
+                'access': access.rights
+            }
+
+        hooks = {
+            'NtCreateFile': enter_NtCreateFile,
+        }
+        events, exec_time = self.vm.run_test(hooks=hooks)
+        # writing events
+        logging.debug('Writing events...')
+        with open('events.json', 'w') as f:
+            json.dump(events, f, indent=4)
+        logging.info('Test execution time {}'.format(exec_time))
+        # checking if we find the event where the file is opened
+        event_found = [e for e in events if e.get('hook')
+                       and e['hook']['object_name'].find('foobar.txt') != -1
+                       and 'FILE_WRITE_DATA' in e['hook']['access']]
+        self.assertTrue(event_found)
+
+    def test_deletefile(self):
+        binary_path = os.path.join(self.script_dir, 'binaries', 'delete_file.exe')
+        self.vm.cdrom.set_executable(binary_path)
+
+        def enter_NtOpenFile(syscall):
+            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
+            obj = ObjectAttributes(object_attributes, syscall.process)
+            buffer = obj.ObjectName.Buffer
+            access = FileAccessMask(DesiredAccess)
+            syscall.hook = {
+                'object_name': buffer,
+                'access': access.rights
+            }
+
+        def enter_NtCreateFile(syscall):
+            KeyHandle, DesiredAccess, object_attributes = syscall.collect_args(3)
+            obj = ObjectAttributes(object_attributes, syscall.process)
+            buffer = obj.ObjectName.Buffer
+            access = FileAccessMask(DesiredAccess)
+            syscall.hook = {
+                'object_name': buffer,
+                'access': access.rights
+            }
+
+        hooks = {
+            'NtOpenFile': enter_NtOpenFile,
+            'NtCreateFile': enter_NtCreateFile,
+        }
+        events, exec_time = self.vm.run_test(hooks=hooks)
+        # writing events
+        logging.debug('Writing events...')
+        with open('events.json', 'w') as f:
+            json.dump(events, f, indent=4)
+        logging.info('Test execution time {}'.format(exec_time))
+        # checking if we find the event where the file is opened
+        event_found = [e for e in events if e.get('hook')
+                       and e['hook']['object_name'].find('foobar.txt') != -1
+                       and 'DELETE' in e['hook']['access']]
         self.assertTrue(event_found)

--- a/tests/unittest.cfg
+++ b/tests/unittest.cfg
@@ -1,0 +1,8 @@
+[unittest]
+plugins = nose2.plugins.layers
+          nose2.plugins.attrib
+
+[layer-reporter]
+always-on = False
+colors = True
+

--- a/tests/vmtest_helper.py
+++ b/tests/vmtest_helper.py
@@ -1,0 +1,144 @@
+import os
+import sys
+import logging
+import time
+import libvirt
+import socket
+import datetime
+from threading import Thread, Event
+import xml.etree.ElementTree as tree
+
+# local
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+from nitro.backend import Backend
+
+SNAPSHOT_BASE = 'base'
+
+
+def wait_winrm(ip_addr, opened=True):
+    while True:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        state = s.connect_ex((ip_addr, 5985))
+        if state == 0 and opened:
+            break
+        elif state != 0 and not opened:
+            # received a RST, port is closed
+            break
+        time.sleep(1)
+
+
+class NitroThread(Thread):
+
+    def __init__(self, domain, analyze=False, hooks=None):
+        super().__init__()
+        self.domain = domain
+        self.analyze_enabled = analyze
+        self.backend = Backend(self.domain, analyze)
+        self.setup_hooks(hooks)
+        self.stop_request = Event()
+        self.total_time = None
+        self.events = []
+
+    def setup_hooks(self, hooks):
+        if hooks:
+            for name, callback in hooks.items():
+                self.backend.define_hook(name, callback)
+
+    def run(self):
+        # start timer
+        start_time = datetime.datetime.now()
+        self.backend.nitro.set_traps(True)
+        for event in self.backend.nitro.listen():
+            if self.analyze_enabled:
+                syscall = self.backend.process_event(event)
+                ev_info = syscall.info()
+            else:
+                ev_info = event.info()
+            self.events.append(ev_info)
+            if self.stop_request.isSet():
+                break
+        self.backend.stop()
+        # stop timer
+        stop_time = datetime.datetime.now()
+        self.total_time = str(stop_time - start_time)
+
+    def stop(self):
+        self.stop_request.set()
+        self.join()
+
+
+class VMTestHelper:
+
+    def __init__(self, domain):
+        # looking for a nitro_<vm> in qemu:///system
+        self.domain = domain
+        # revert to base snapshot if present
+        try:
+            snap = self.domain.snapshotLookupByName(SNAPSHOT_BASE)
+            logging.info('Reverting to base snapshot')
+            self.domain.revertToSnapshot(snap)
+        except libvirt.libvirtError:
+            logging.warning('Missing snapshot "{}"'.format(SNAPSHOT_BASE))
+
+    def wait_for_ip(self, network_name='default'):
+        # find MAC address
+        dom_elem = tree.fromstring(self.domain.XMLDesc())
+        mac_addr = dom_elem.find("./devices/interface[@type='network']/mac").get('address')
+        logging.debug('MAC address : {}'.format(mac_addr))
+        while True:
+            net = self.domain.connect().networkLookupByName(network_name)
+            leases = net.DHCPLeases()
+            found = [l for l in leases if l['mac'] == mac_addr]
+            if found:
+                return found[0]['ipaddr']
+            time.sleep(1)
+
+    def mount_cdrom(self, cdrom_path):
+        logging.info('Mounting CDROM image')
+        dom_elem = tree.fromstring(self.domain.XMLDesc())
+        # find cdrom
+        cdrom_elem = dom_elem.find("./devices/disk[@device='cdrom']")
+        # find source
+        source_elem = cdrom_elem.find('./source')
+        if source_elem is None:
+            tree.SubElement(cdrom_elem, 'source')
+            source_elem = cdrom_elem.find('./source')
+        source_elem.set('file', cdrom_path)
+        new_xml = tree.tostring(cdrom_elem).decode('utf-8')
+        self.domain.updateDeviceFlags(new_xml, libvirt.VIR_DOMAIN_AFFECT_LIVE)
+
+    def run(self, cdrom_iso, analyze=True, idle=False, hooks=None):
+        # start domain
+        logging.info('Testing {}'.format(self.domain.name()))
+        self.domain.create()
+        # wait for IP address
+        ip = self.wait_for_ip()
+        logging.info('IP address : {}'.format(ip))
+        # wait for WinRM to be available
+        wait_winrm(ip, True)
+        if idle:
+            # wait for idle
+            idle_wait = 60 * 5
+            logging.info('Waiting for Windows to be idle (5 min)')
+            time.sleep(idle_wait)
+        # run nitro before inserting CDROM
+        nitro = NitroThread(self.domain, analyze, hooks)
+        nitro.start()
+        # mount cdrom, test is executed
+        self.mount_cdrom(cdrom_iso)
+        # test is executing under Nitro monitoring
+        # wait on WinRM to be closed
+        wait_winrm(ip, False)
+        # # wait for nitro thread to terminate properly
+        nitro.stop()
+        self.domain.shutdown()
+        # stop domain
+        while self.domain.state()[0] != libvirt.VIR_DOMAIN_SHUTOFF:
+            time.sleep(1)
+        result = (nitro.events, nitro.total_time)
+        return result
+
+    def force_shutdown(self):
+        if self.domain.isActive():
+            logging.info('Force VM shutdown, the test probably failed')
+            self.domain.destroy()


### PR DESCRIPTION
- Refactor the test API, splitting `test_nitro` in multiple files
- Allow the test to control the `Nitro` loop by itself
- Add documentation