### PR TITLE
Callback backend

### DIFF
--- a/nitro/backend.py
+++ b/nitro/backend.py
@@ -189,7 +189,10 @@ class Backend:
             p = self.processes[cr3]
         except KeyError:
             p = self.find_eprocess(cr3)
+            # index by cr3 or pid
+            # a callback might want to search by pid
             self.processes[cr3] = p
+            self.processes[p.pid] = p
         return p
 
     def find_eprocess(self, cr3):

--- a/nitro/backend.py
+++ b/nitro/backend.py
@@ -158,7 +158,7 @@ class Backend:
         else:
             try:
                 logging.debug('Processing hook {} - {}'.format(syscall.event.direction.name, hook.__name__))
-                hook(syscall)
+                hook(syscall, self)
             except InconsistentMemoryError:
                 self.stats['memory_access_error'] += 1
                 logging.exception('Memory access error')

--- a/tests/README.md
+++ b/tests/README.md
@@ -95,7 +95,7 @@ def test_01(self):
     self.vm.cdrom.set_script(script, powershell=True)
     
     # 2. define your Nitro callbacks
-    def enter_NtOpenFile(syscall):
+    def enter_NtOpenFile(syscall, backend):
         logging.info('enter in NtOpenFile')
         syscall.hook = 'foobar'
         

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -17,7 +17,7 @@ class TestWindows(unittest.TestCase):
         script = 'Get-Content \"{}\"'.format(file_path)
         self.vm.cdrom.set_script(script, powershell=True)
 
-        def enter_NtOpenFile(syscall):
+        def enter_NtOpenFile(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)
@@ -28,7 +28,7 @@ class TestWindows(unittest.TestCase):
                 'access': access.rights
             }
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)
@@ -61,14 +61,14 @@ class TestWindows(unittest.TestCase):
         script = 'New-Item \"HKCU:\\{}\" -Force | New-ItemProperty -Name foobar -Value true -PropertyType STRING -Force'.format(key_path)
         self.vm.cdrom.set_script(script, powershell=True)
 
-        def enter_NtOpenKey(syscall):
+        def enter_NtOpenKey(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)
             buffer = obj.ObjectName.Buffer
             syscall.hook = buffer
 
-        def enter_NtCreateKey(syscall):
+        def enter_NtCreateKey(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)
@@ -93,7 +93,7 @@ class TestWindows(unittest.TestCase):
         binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_read.exe')
         self.vm.cdrom.set_executable(binary_path)
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)
@@ -123,7 +123,7 @@ class TestWindows(unittest.TestCase):
         binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_write.exe')
         self.vm.cdrom.set_executable(binary_path)
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)
@@ -153,7 +153,7 @@ class TestWindows(unittest.TestCase):
         binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_execute.exe')
         self.vm.cdrom.set_executable(binary_path)
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)
@@ -183,7 +183,7 @@ class TestWindows(unittest.TestCase):
         binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_all.exe')
         self.vm.cdrom.set_executable(binary_path)
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)
@@ -213,7 +213,7 @@ class TestWindows(unittest.TestCase):
         binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_append.exe')
         self.vm.cdrom.set_executable(binary_path)
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)
@@ -243,7 +243,7 @@ class TestWindows(unittest.TestCase):
         binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_file_execute.exe')
         self.vm.cdrom.set_executable(binary_path)
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)
@@ -273,7 +273,7 @@ class TestWindows(unittest.TestCase):
         binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_read_data.exe')
         self.vm.cdrom.set_executable(binary_path)
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)
@@ -333,7 +333,7 @@ class TestWindows(unittest.TestCase):
         binary_path = os.path.join(self.script_dir, 'binaries', 'delete_file.exe')
         self.vm.cdrom.set_executable(binary_path)
 
-        def enter_NtOpenFile(syscall):
+        def enter_NtOpenFile(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)
@@ -344,7 +344,7 @@ class TestWindows(unittest.TestCase):
                 'access': access.rights
             }
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)

--- a/tests/test_windows_debug.py
+++ b/tests/test_windows_debug.py
@@ -16,7 +16,7 @@ class TestWindowsDebug(unittest.TestCase):
         script = 'New-Item c:\\Windows\\foobar.txt -type file -force'
         self.vm.cdrom.set_script(script, powershell=True)
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             named_args = ['KeyHandle', 'DesiredAccess', 'ObjectAttributes',
                     'IoStatusBlock', 'AllocationSize', 'FileAttributes',
                     'ShareAccess', 'CreateDisposition', 'CreateOptions',
@@ -39,7 +39,7 @@ class TestWindowsDebug(unittest.TestCase):
         script = 'New-Item \"HKCU:\\{}\" -Force | New-ItemProperty -Name foobar -Value true -PropertyType STRING -Force'.format(key_path)
         self.vm.cdrom.set_script(script, powershell=True)
 
-        def callback(syscall):
+        def callback(syscall, backend):
             named_args = ['KeyHandle', 'DesiredAccess', 'ObjectAttributes',
                     'TitleIndex', 'Class', 'CreateOptions', 'Disposition']
             for i, name in enumerate(named_args):
@@ -60,7 +60,7 @@ class TestWindowsDebug(unittest.TestCase):
         script = 'New-Item \"HKCU:\\{}\" -Force | New-ItemProperty -Name foobar -Value true -PropertyType STRING -Force'.format(key_path)
         self.vm.cdrom.set_script(script, powershell=True)
 
-        def enter_NtSetValueKey(syscall):
+        def enter_NtSetValueKey(syscall, backend):
             named_args = ['KeyHandle', 'ValueName', 'TitleIndex',
                     'Type', 'Data', 'DataSize']
             for i, name in enumerate(named_args):
@@ -80,7 +80,7 @@ class TestWindowsDebug(unittest.TestCase):
         script = 'Get-ChildItem C:\\Windows'
         self.vm.cdrom.set_script(script, powershell=True)
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             named_args = ['KeyHandle', 'DesiredAccess', 'ObjectAttributes',
                     'IoStatusBlock', 'AllocationSize', 'FileAttributes',
                     'ShareAccess', 'CreateDisposition', 'CreateOptions',
@@ -112,7 +112,7 @@ class TestWindowsDebug(unittest.TestCase):
         script = 'Get-ChildItem C:\\Windows'
         self.vm.cdrom.set_script(script, powershell=True)
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             named_args = ['KeyHandle', 'DesiredAccess', 'ObjectAttributes',
                     'IoStatusBlock', 'AllocationSize', 'FileAttributes',
                     'ShareAccess', 'CreateDisposition', 'CreateOptions',
@@ -144,7 +144,7 @@ class TestWindowsDebug(unittest.TestCase):
         script = 'Get-ChildItem C:\\Windows'
         self.vm.cdrom.set_script(script, powershell=True)
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             named_args = ['KeyHandle', 'DesiredAccess', 'ObjectAttributes',
                     'IoStatusBlock', 'AllocationSize', 'FileAttributes',
                     'ShareAccess', 'CreateDisposition', 'CreateOptions',


### PR DESCRIPTION
Reintroduce the backend as callback parameter.

A callback might need to check the backend to get the `backend.processes` process dict.

Also, processes are indexed by pid also now.