### PR TITLE
Syscall filtering

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,8 +15,9 @@ Options:
 import logging
 import signal
 import json
-import libvirt
 from pprint import pprint
+
+import libvirt
 from docopt import docopt
 
 from nitro.nitro import Nitro
@@ -42,6 +43,7 @@ class NitroRunner:
         con = libvirt.open('qemu:///system')
         self.domain = con.lookupByName(vm_name)
         self.events = []
+        self.nitro = None
         # define new SIGINT handler, to stop nitro
         signal.signal(signal.SIGINT, self.sigint_handler)
 
@@ -73,7 +75,7 @@ class NitroRunner:
             with open('events.json', 'w') as f:
                 json.dump(self.events, f, indent=4)
 
-    def sigint_handler(self, signal, frame):
+    def sigint_handler(self, *args, **kwargs):
         logging.info('CTRL+C received, stopping Nitro')
         self.nitro.stop()
 

--- a/main.py
+++ b/main.py
@@ -16,20 +16,11 @@ import logging
 import signal
 import json
 import libvirt
-import time
 from pprint import pprint
 from docopt import docopt
 
 from nitro.nitro import Nitro
 from nitro.libvmi import LibvmiError
-
-run = True
-
-# def new signal for SIGINT
-def sigint_handler(signal, frame):
-    global run
-    run = False
-signal.signal(signal.SIGINT, sigint_handler)
 
 
 def init_logger():
@@ -38,40 +29,61 @@ def init_logger():
     logger.setLevel(logging.INFO)
 
 
-def main(args):
-    vm_name = args['<vm_name>']
-    # get domain from libvirt
-    con = libvirt.open('qemu:///system')
-    domain = con.lookupByName(vm_name)
+def callback(syscall, backend):
+    pass
 
-    events = []
+class NitroRunner:
 
-    analyze_enabled = not args['--nobackend']
+    def __init__(self, vm_name, analyze_enabled, stdout):
+        self.vm_name = vm_name
+        self.analyze_enabled = analyze_enabled
+        self.stdout = stdout
+        # get domain from libvirt
+        con = libvirt.open('qemu:///system')
+        self.domain = con.lookupByName(vm_name)
+        self.events = []
+        # define new SIGINT handler, to stop nitro
+        signal.signal(signal.SIGINT, self.sigint_handler)
 
-    with Nitro(domain, analyze_enabled) as nitro:
-        nitro.listener.set_traps(True)
-        for event in nitro.listen():
+    def run(self):
+        self.nitro = Nitro(self.domain, self.analyze_enabled)
+        if self.analyze_enabled:
+            # defining hooks
+            self.nitro.backend.define_hook('NtOpenFile', callback)
+            self.nitro.backend.define_hook('NtCreateFile', callback)
+            self.nitro.backend.define_hook('NtClose', callback)
+
+        self.nitro.listener.set_traps(True)
+        for event in self.nitro.listen():
             event_info = event.as_dict()
-            if analyze_enabled:
+            if self.analyze_enabled:
                 try:
-                    syscall = nitro.backend.process_event(event)
+                    syscall = self.nitro.backend.process_event(event)
                 except LibvmiError:
                     logging.error("Backend event processing failure")
                 else:
                     event_info = syscall.as_dict()
-            if args['--stdout']:
+            if self.stdout:
                 pprint(event_info, width=1)
             else:
-                events.append(event_info)
+                self.events.append(event_info)
 
-            # stop properly by CTRL+C
-            if not run:
-                break
+        if self.events:
+            logging.info('Writing events')
+            with open('events.json', 'w') as f:
+                json.dump(self.events, f, indent=4)
 
-    if events:
-        logging.info('Writing events')
-        with open('events.json', 'w') as f:
-            json.dump(events, f, indent=4)
+    def sigint_handler(self, signal, frame):
+        logging.info('CTRL+C received, stopping Nitro')
+        self.nitro.stop()
+
+
+def main(args):
+    vm_name = args['<vm_name>']
+    analyze_enabled = False if args['--nobackend'] else True
+    stdout = args['--stdout']
+    runner = NitroRunner(vm_name, analyze_enabled, stdout)
+    runner.run()
 
 
 if __name__ == '__main__':

--- a/nitro/backends/backend.py
+++ b/nitro/backends/backend.py
@@ -11,12 +11,15 @@ class Backend:
         "libvmi",
         "hooks",
         "stats",
-        "listener"
+        "listener",
+        "syscall_filtering"
     )
 
-    def __init__(self, domain, libvmi):
+    def __init__(self, domain, libvmi, listener, syscall_filtering=True):
         self.domain = domain
         self.libvmi = libvmi
+        self.listener  = listener
+        self.syscall_filtering = syscall_filtering
         self.hooks = {
             SyscallDirection.enter: {},
             SyscallDirection.exit: {}

--- a/nitro/backends/backend.py
+++ b/nitro/backends/backend.py
@@ -2,7 +2,7 @@ import logging
 import json
 from collections import defaultdict
 
-from nitro.event import SyscallDirection, SyscallType
+from nitro.event import SyscallDirection
 from nitro.libvmi import LibvmiError
 
 class Backend:
@@ -18,7 +18,7 @@ class Backend:
     def __init__(self, domain, libvmi, listener, syscall_filtering=True):
         self.domain = domain
         self.libvmi = libvmi
-        self.listener  = listener
+        self.listener = listener
         self.syscall_filtering = syscall_filtering
         self.hooks = {
             SyscallDirection.enter: {},
@@ -37,7 +37,8 @@ class Backend:
             pass
         else:
             try:
-                logging.debug('Processing hook %s - %s', syscall.event.direction.name, hook.__name__)
+                logging.debug('Processing hook %s - %s',
+                              syscall.event.direction.name, hook.__name__)
                 hook(syscall, self)
             # FIXME: There should be a way for OS specific backends to report these
             # except InconsistentMemoryError: #

--- a/nitro/backends/factory.py
+++ b/nitro/backends/factory.py
@@ -7,11 +7,15 @@ BACKENDS = {
     VMIOS.WINDOWS: WindowsBackend
 }
 
-def BackendNotFoundError(Exception):
+class BackendNotFoundError(Exception):
     pass
 
 def get_backend(domain, listener, syscall_filtering):
-    """Return backend based on libvmi configuration. If analyze if False, returns a dummy backend that does not analyze system calls. Returns None if the backend is missing"""
+    """Return backend based on libvmi configuration.
+    If analyze if False, returns a dummy backend
+    that does not analyze system calls.
+    Returns None if the backend is missing
+    """
     libvmi = Libvmi(domain.name())
     os_type = libvmi.get_ostype()
     try:

--- a/nitro/backends/factory.py
+++ b/nitro/backends/factory.py
@@ -10,12 +10,12 @@ BACKENDS = {
 def BackendNotFoundError(Exception):
     pass
 
-def get_backend(domain):
+def get_backend(domain, listener, syscall_filtering):
     """Return backend based on libvmi configuration. If analyze if False, returns a dummy backend that does not analyze system calls. Returns None if the backend is missing"""
     libvmi = Libvmi(domain.name())
     os_type = libvmi.get_ostype()
     try:
-        return BACKENDS[os_type](domain, libvmi)
+        return BACKENDS[os_type](domain, libvmi, listener, syscall_filtering)
     except KeyError:
         raise BackendNotFoundError('Unable to find an appropritate backend for'
                                    'this OS: {}'.format(os_type))

--- a/nitro/backends/linux/arguments.py
+++ b/nitro/backends/linux/arguments.py
@@ -1,5 +1,3 @@
-import struct
-
 from nitro.event import SyscallType
 from nitro.backends.arguments import ArgumentMap, SyscallArgumentType
 

--- a/nitro/backends/linux/backend.py
+++ b/nitro/backends/linux/backend.py
@@ -25,8 +25,8 @@ class LinuxBackend(Backend):
         "pgd_offset",
     )
 
-    def __init__(self, domain, libvmi):
-        super().__init__(domain, libvmi)
+    def __init__(self, domain, libvmi, listener, syscall_filtering=True):
+        super().__init__(domain, libvmi, listener, syscall_filtering)
         self.sys_call_table_addr = self.libvmi.translate_ksym2v("sys_call_table")
         logging.debug("sys_call_table at %s", hex(self.sys_call_table_addr))
 

--- a/nitro/backends/linux/backend.py
+++ b/nitro/backends/linux/backend.py
@@ -10,7 +10,8 @@ from nitro.backends.linux.process import LinuxProcess
 from nitro.backends.backend import Backend
 from nitro.backends.linux.arguments import LinuxArgumentMap
 
-# Technically, I do not think using this the way I do is correct since it might be different for the VM
+# Technically, I do not think using this the way
+#  I do is correct since it might be different for the VM
 VOID_P_SIZE = sizeof(c_void_p)
 
 HANDLER_NAME_REGEX = re.compile(r"^(SyS|sys)_(?P<name>.+)")
@@ -70,9 +71,12 @@ class LinuxBackend(Backend):
         return syscall
 
     def get_syscall_name(self, rax):
-        p_addr = self.sys_call_table_addr + (rax * VOID_P_SIZE) # address of the pointer within the sys_call_table array
-        addr = self.libvmi.read_addr_va(p_addr, 0) # get the address of the procedure
-        return self.libvmi.translate_v2ksym(addr) # translate the address into a name
+        # address of the pointer within the sys_call_table array
+        p_addr = self.sys_call_table_addr + (rax * VOID_P_SIZE)
+        # get the address of the procedure
+        addr = self.libvmi.read_addr_va(p_addr, 0)
+        # translate the address into a name
+        return self.libvmi.translate_v2ksym(addr)
 
     def associate_process(self, cr3):
         """Get Process associated with CR3"""

--- a/nitro/backends/linux/backend.py
+++ b/nitro/backends/linux/backend.py
@@ -95,7 +95,23 @@ class LinuxBackend(Backend):
             if next_ == head:
                 break
 
+    def define_hook(self, name, callback, direction=SyscallDirection.enter):
+        super().define_hook(name, callback, direction)
+        if self.syscall_filtering:
+            self.add_syscall_filter(name)
+
+    def undefine_hook(self, name, direction=SyscallDirection.enter):
+        super().undefine_hook(name, direction)
+        if self.syscall_filtering:
+            self.remove_syscall_filter(name)
+
+    def add_syscall_filter(self, syscall_name):
+        raise RuntimeError('Unimplemented feature')
+
+    def remove_syscall_filter(self, syscall_name):
+        raise RuntimeError('Unimplemented feature')
+
+
 def clean_name(name):
     matches = HANDLER_NAME_REGEX.search(name)
     return matches.group("name") if matches is not None else name
-

--- a/nitro/backends/linux/process.py
+++ b/nitro/backends/linux/process.py
@@ -15,6 +15,3 @@ class LinuxProcess(Process):
         self.task_struct = task_struct
         self.pid = self.libvmi.read_32(self.task_struct + pid_offset, 0)
         self.name = self.libvmi.read_str_va(self.task_struct + name_offset, 0)
-
-
-

--- a/nitro/backends/windows/arguments.py
+++ b/nitro/backends/windows/arguments.py
@@ -1,5 +1,3 @@
-import struct
-
 from nitro.event import SyscallType
 from nitro.backends.arguments import ArgumentMap, SyscallArgumentType
 

--- a/nitro/backends/windows/backend.py
+++ b/nitro/backends/windows/backend.py
@@ -131,10 +131,7 @@ class WindowsBackend(Backend):
             raise RuntimeError('Unable to define hook, introspection is disabled')
         logging.info('Defining hook on {}'.format(name))
         if self.syscall_filtering:
-            syscall_nb = self.find_syscall_nb(name)
-            if syscall_nb is None:
-                raise RuntimeError('Unable to find syscall number for %s' % name)
-            self.nitro.add_syscall_filter(syscall_nb)
+            self.set_syscall_filter(name, True)
         self.hooks[direction][name] = callback
 
     def undefine_hook(self, name, direction=SyscallDirection.enter):
@@ -142,10 +139,7 @@ class WindowsBackend(Backend):
             raise RuntimeError('Unable to define hook, introspection is disabled')
         logging.info('Removing hook on {}'.format(name))
         if self.syscall_filtering:
-            syscall_nb = self.find_syscall_nb(name)
-            if syscall_nb is None:
-                raise RuntimeError('Unable to find syscall number for %s' % name)
-            self.nitro.remove_syscall_filter(syscall_nb)
+            self.set_syscall_filter(name, False)
         self.hooks[direction].pop(name)
 
     def find_syscall_nb(self, syscall_name):
@@ -197,5 +191,16 @@ class WindowsBackend(Backend):
             syscall_name = 'Table{}!Unknown'.format(idx)
         return syscall_name
 
+    def set_syscall_filter(self, syscall_name, defined=True):
+        syscall_nb = self.find_syscall_nb(syscall_name)
+        if syscall_nb is None:
+            raise RuntimeError('Unable to find syscall number for %s' % name)
+        if defined:
+            self.nitro.add_syscall_filter(syscall_nb)
+        else:
+            self.nitro.remove_syscall_filter(syscall_nb)
+
+
 def clean_name(name):
     return name.split('!')[-1]
+

--- a/nitro/backends/windows/backend.py
+++ b/nitro/backends/windows/backend.py
@@ -143,10 +143,9 @@ class WindowsBackend(Backend):
         self.hooks[direction].pop(name)
 
     def find_syscall_nb(self, syscall_name):
-        pattern = re.compile(r'^.*{}$'.format(syscall_name))
         for ssdt in self.sdt:
             for syscall_nb, full_name in ssdt['ServiceTable'].items():
-                if pattern.match(full_name):
+                if re.match(r'^.*{}$'.format(syscall_name), full_name):
                     return syscall_nb
         return None
 

--- a/nitro/backends/windows/backend.py
+++ b/nitro/backends/windows/backend.py
@@ -202,4 +202,3 @@ class WindowsBackend(Backend):
 
 def clean_name(name):
     return name.split('!')[-1]
-

--- a/nitro/backends/windows/backend.py
+++ b/nitro/backends/windows/backend.py
@@ -127,6 +127,8 @@ class WindowsBackend(Backend):
         return syscall
 
     def define_hook(self, name, callback, direction=SyscallDirection.enter):
+        if not self.analyze:
+            raise RuntimeError('Unable to define hook, introspection is disabled')
         logging.info('Defining hook on {}'.format(name))
         if self.syscall_filtering:
             syscall_nb = self.find_syscall_nb(name)
@@ -136,6 +138,8 @@ class WindowsBackend(Backend):
         self.hooks[direction][name] = callback
 
     def undefine_hook(self, name, direction=SyscallDirection.enter):
+        if not self.analyze:
+            raise RuntimeError('Unable to define hook, introspection is disabled')
         logging.info('Removing hook on {}'.format(name))
         if self.syscall_filtering:
             syscall_nb = self.find_syscall_nb(name)

--- a/nitro/backends/windows/backend.py
+++ b/nitro/backends/windows/backend.py
@@ -131,7 +131,7 @@ class WindowsBackend(Backend):
             raise RuntimeError('Unable to define hook, introspection is disabled')
         logging.info('Defining hook on {}'.format(name))
         if self.syscall_filtering:
-            self.set_syscall_filter(name, True)
+            self.add_syscall_filter(name)
         self.hooks[direction][name] = callback
 
     def undefine_hook(self, name, direction=SyscallDirection.enter):
@@ -139,7 +139,7 @@ class WindowsBackend(Backend):
             raise RuntimeError('Unable to define hook, introspection is disabled')
         logging.info('Removing hook on {}'.format(name))
         if self.syscall_filtering:
-            self.set_syscall_filter(name, False)
+            self.remove_syscall_filter(name)
         self.hooks[direction].pop(name)
 
     def find_syscall_nb(self, syscall_name):

--- a/nitro/backends/windows/backend.py
+++ b/nitro/backends/windows/backend.py
@@ -190,14 +190,17 @@ class WindowsBackend(Backend):
             syscall_name = 'Table{}!Unknown'.format(idx)
         return syscall_name
 
-    def set_syscall_filter(self, syscall_name, defined=True):
+    def add_syscall_filter(self, syscall_name):
         syscall_nb = self.find_syscall_nb(syscall_name)
         if syscall_nb is None:
-            raise RuntimeError('Unable to find syscall number for %s' % name)
-        if defined:
-            self.nitro.add_syscall_filter(syscall_nb)
-        else:
-            self.nitro.remove_syscall_filter(syscall_nb)
+            raise RuntimeError('Unable to find syscall number for %s' % syscall_name)
+        self.nitro.add_syscall_filter(syscall_nb)
+
+    def remove_syscall_filter(self, syscall_name):
+        syscall_nb = self.find_syscall_nb(syscall_name)
+        if syscall_nb is None:
+            raise RuntimeError('Unable to find syscall number for %s' % syscall_name)
+        self.nitro.remove_syscall_filter(syscall_nb)
 
 
 def clean_name(name):

--- a/nitro/backends/windows/backend.py
+++ b/nitro/backends/windows/backend.py
@@ -10,14 +10,14 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import libvirt
 
-
-from nitro.event import SyscallDirection, SyscallType
+from nitro.event import SyscallDirection
 from nitro.syscall import Syscall
 from nitro.backends.windows.process import WindowsProcess
 from nitro.backends.backend import Backend
 from nitro.backends.windows.arguments import WindowsArgumentMap
 
 GETSYMBOLS_SCRIPT = 'get_symbols.py'
+
 
 class WindowsBackend(Backend):
     __slots__ = (
@@ -53,9 +53,10 @@ class WindowsBackend(Backend):
         with TemporaryDirectory() as tmp_dir:
             with NamedTemporaryFile(dir=tmp_dir) as ram_dump:
                 # chmod to be r/w by everyone
-                os.chmod(ram_dump.name, stat.S_IRUSR | stat.S_IWUSR |
-                                        stat.S_IRGRP | stat.S_IWGRP |
-                                        stat.S_IROTH | stat.S_IWOTH)
+                os.chmod(ram_dump.name,
+                         stat.S_IRUSR | stat.S_IWUSR |
+                         stat.S_IRGRP | stat.S_IWGRP |
+                         stat.S_IROTH | stat.S_IWOTH)
                 # take a ram dump
                 logging.info('Dumping physical memory to %s', ram_dump.name)
                 flags = libvirt.VIR_DUMP_MEMORY_ONLY
@@ -63,7 +64,8 @@ class WindowsBackend(Backend):
                 self.domain.coreDumpWithFormat(ram_dump.name, dumpformat, flags)
                 # build symbols.py absolute path
                 script_dir = os.path.dirname(os.path.realpath(__file__))
-                symbols_script_path = os.path.join(script_dir, GETSYMBOLS_SCRIPT)
+                symbols_script_path = os.path.join(script_dir,
+                                                   GETSYMBOLS_SCRIPT)
                 # call rekall on ram dump
                 logging.info('Extracting symbols with Rekall')
                 python2 = shutil.which('python2')
@@ -159,14 +161,19 @@ class WindowsBackend(Backend):
 
         while flink != ps_head:
             # get start of EProcess
-            start_eproc = flink - self.symbols['offsets']['EPROCESS']['ActiveProcessLinks']
+            start_eproc = flink - self.symbols['offsets']['EPROCESS'][
+                'ActiveProcessLinks']
             # move to start of DirectoryTableBase
-            directory_table_base_off = start_eproc + self.symbols['offsets']['KPROCESS']['DirectoryTableBase']
+            directory_table_base_off = start_eproc + \
+                                       self.symbols['offsets']['KPROCESS'][
+                                           'DirectoryTableBase']
             # read directory_table_base
-            directory_table_base = self.libvmi.read_addr_va(directory_table_base_off, 0)
+            directory_table_base = self.libvmi.read_addr_va(
+                directory_table_base_off, 0)
             # compare to our cr3
             if cr3 == directory_table_base:
-                return WindowsProcess(self.libvmi, cr3, start_eproc, self.symbols)
+                return WindowsProcess(self.libvmi, cr3, start_eproc,
+                                      self.symbols)
             # read new flink
             flink = self.libvmi.read_addr_va(flink, 0)
         raise RuntimeError('Process not found')
@@ -177,7 +184,8 @@ class WindowsBackend(Backend):
         try:
             syscall_name = self.sdt[idx]['ServiceTable'][ssn]
         except (KeyError, IndexError):
-            # this code should not be reached, because there is only 2 SSDT's defined in Windows (Nt and Win32k)
+            # this code should not be reached,
+            # because there is only 2 SSDT's defined in Windows (Nt and Win32k)
             # the 2 others are NULL
             syscall_name = 'Table{}!Unknown'.format(idx)
         return syscall_name
@@ -185,13 +193,15 @@ class WindowsBackend(Backend):
     def add_syscall_filter(self, syscall_name):
         syscall_nb = self.find_syscall_nb(syscall_name)
         if syscall_nb is None:
-            raise RuntimeError('Unable to find syscall number for %s' % syscall_name)
+            raise RuntimeError(
+                'Unable to find syscall number for %s' % syscall_name)
         self.listener.add_syscall_filter(syscall_nb)
 
     def remove_syscall_filter(self, syscall_name):
         syscall_nb = self.find_syscall_nb(syscall_name)
         if syscall_nb is None:
-            raise RuntimeError('Unable to find syscall number for %s' % syscall_name)
+            raise RuntimeError(
+                'Unable to find syscall number for %s' % syscall_name)
         self.listener.remove_syscall_filter(syscall_nb)
 
 

--- a/nitro/backends/windows/types.py
+++ b/nitro/backends/windows/types.py
@@ -236,4 +236,3 @@ class FileBasicInformation(WinStruct):
 
     def __init__(self, addr, process):
         super().__init__(addr, process)
-

--- a/nitro/backends/windows/types.py
+++ b/nitro/backends/windows/types.py
@@ -1,19 +1,19 @@
-import logging
 import struct
+
 
 class InconsistentMemoryError(Exception):
     pass
 
 
 class WinStruct(object):
-
     _fields_ = []
 
     def __init__(self, addr, process):
         # logging.debug('Building %s from %s', self.__class__.__name__, hex(addr))
         for f_offset, f_name, f_format in self._fields_:
             if isinstance(f_format, str):
-                # logging.debug('Field {}, {}, at {} + {}'.format(f_name, f_format, hex(addr), hex(f_offset)))
+                # logging.debug('Field {}, {}, at {} + {}'
+                #               .format(f_name, f_format, hex(addr), hex(f_offset)))
                 f_size = struct.calcsize(f_format)
                 content = process.read_memory(addr + f_offset, f_size)
                 f_value, *rest = struct.unpack(f_format, content)
@@ -26,7 +26,6 @@ class WinStruct(object):
 
 
 class ObjectAttributes(WinStruct):
-
     __slots__ = (
         'Length',
         'RootDirectory',
@@ -34,10 +33,10 @@ class ObjectAttributes(WinStruct):
     )
 
     _fields_ = [
-            (0, 'Length',  'I'),
-            (0x8, 'RootDirectory', 'P'),
-            (0x10, 'ObjectName', 'P'),
-            ]
+        (0, 'Length', 'I'),
+        (0x8, 'RootDirectory', 'P'),
+        (0x10, 'ObjectName', 'P'),
+    ]
 
     def __init__(self, addr, process):
         super().__init__(addr, process)
@@ -48,7 +47,6 @@ class ObjectAttributes(WinStruct):
 
 
 class ClientID(WinStruct):
-
     __slots__ = (
         'UniqueProcess',
         'UniqueThread'
@@ -64,7 +62,6 @@ class ClientID(WinStruct):
 
 
 class LargeInteger(WinStruct):
-
     __slots__ = (
         'LowPart',
         'HighPart'
@@ -75,14 +72,13 @@ class LargeInteger(WinStruct):
         (0, 'LowPart', 'I'),
         (4, 'HighPart', 'I'),
         (0, 'QuadPart', 'q')
-        ]
+    ]
 
     def __init__(self, addr, process):
         super().__init__(addr, process)
 
 
 class UnicodeString(WinStruct):
-
     __slots__ = (
         'Length',
         'MaximumLength',
@@ -90,10 +86,10 @@ class UnicodeString(WinStruct):
     )
 
     _fields_ = [
-            (0, 'Length', 'H'),
-            (0x2, 'MaximumLength', 'H'),
-            (0x8, 'Buffer', 'P'),
-            ]
+        (0, 'Length', 'H'),
+        (0x2, 'MaximumLength', 'H'),
+        (0x8, 'Buffer', 'P'),
+    ]
 
     def __init__(self, addr, process):
         super().__init__(addr, process)
@@ -106,7 +102,6 @@ class UnicodeString(WinStruct):
 
 
 class PEB(WinStruct):
-
     __slots__ = (
         'ProcessParameters'
     )
@@ -122,7 +117,6 @@ class PEB(WinStruct):
 
 
 class RtlUserProcessParameters(WinStruct):
-
     __slots__ = (
         'ImagePathName',
         'CommandLine'
@@ -138,7 +132,6 @@ class RtlUserProcessParameters(WinStruct):
 
 
 class AccessMask:
-
     STANDARD_RIGHTS = [
         (1 << 16, "DELETE"),
         (1 << 17, "READ_CONTROL"),
@@ -155,11 +148,11 @@ class AccessMask:
 
     def __init__(self, desired_access):
         self.rights = []
-        self.rights.extend([right for mask, right in self.STANDARD_RIGHTS if desired_access & mask])
+        self.rights.extend([right for mask, right in self.STANDARD_RIGHTS if
+                            desired_access & mask])
 
 
 class FileAccessMask(AccessMask):
-
     SPECIFIC_RIGHTS = [
         (1 << 0, "FILE_READ_DATA"),
         (1 << 1, "FILE_WRITE_DATA"),
@@ -173,10 +166,11 @@ class FileAccessMask(AccessMask):
 
     def __init__(self, desired_access):
         super().__init__(desired_access)
-        self.rights.extend([right for mask, right in self.SPECIFIC_RIGHTS if desired_access & mask])
+        self.rights.extend([right for mask, right in self.SPECIFIC_RIGHTS if
+                            desired_access & mask])
+
 
 class FileRenameInformation(WinStruct):
-
     __slots__ = (
         'ReplaceIfExists',
         'RootDirectory',
@@ -203,7 +197,6 @@ class FileRenameInformation(WinStruct):
 
 
 class FileDispositionInformation(WinStruct):
-
     __slots__ = (
         'DeleteFile'
     )
@@ -215,8 +208,8 @@ class FileDispositionInformation(WinStruct):
     def __init__(self, addr, process):
         super().__init__(addr, process)
 
-class FileBasicInformation(WinStruct):
 
+class FileBasicInformation(WinStruct):
     __slots__ = (
         'CreationTime',
         'LastAccessTime',

--- a/nitro/event.py
+++ b/nitro/event.py
@@ -68,4 +68,3 @@ class NitroEvent:
         else:
             # send new register to KVM VCPU
             self.vcpu_io.set_regs(self.regs)
-

--- a/nitro/kvm.py
+++ b/nitro/kvm.py
@@ -143,6 +143,7 @@ class VM(IOCTL):
 
     KVM_NITRO_ATTACH_VCPUS = IOR(KVMIO, 0xE2, NitroVCPUs)
     KVM_NITRO_SET_SYSCALL_TRAP = IOW(KVMIO, 0xE3, c_bool)
+    KVM_NITRO_ADD_SYSCALL_FILTER = IOR(KVMIO, 0xEB, c_ulonglong)
 
     def __init__(self, vm_fd):
         super().__init__()
@@ -163,6 +164,13 @@ class VM(IOCTL):
         r = self.make_ioctl(self.KVM_NITRO_SET_SYSCALL_TRAP, byref(c_enabled))
         return r
 
+    def add_syscall_filter(self, syscall_nb):
+        logging.debug('adding syscall filter on %s' % (syscall_nb))
+        c_syscall_nb = c_ulonglong(syscall_nb)
+        r = self.make_ioctl(self.KVM_NITRO_ADD_SYSCALL_FILTER, byref(c_syscall_nb))
+        if r != 0:
+            raise RuntimeError('Error: fail to add syscall filter')
+        return r
 
 class VCPU(IOCTL):
 

--- a/nitro/kvm.py
+++ b/nitro/kvm.py
@@ -144,6 +144,7 @@ class VM(IOCTL):
     KVM_NITRO_ATTACH_VCPUS = IOR(KVMIO, 0xE2, NitroVCPUs)
     KVM_NITRO_SET_SYSCALL_TRAP = IOW(KVMIO, 0xE3, c_bool)
     KVM_NITRO_ADD_SYSCALL_FILTER = IOR(KVMIO, 0xEB, c_ulonglong)
+    KVM_NITRO_REMOVE_SYSCALL_FILTER = IOR(KVMIO, 0xEC, c_ulonglong)
 
     def __init__(self, vm_fd):
         super().__init__()
@@ -170,6 +171,15 @@ class VM(IOCTL):
         r = self.make_ioctl(self.KVM_NITRO_ADD_SYSCALL_FILTER, byref(c_syscall_nb))
         if r != 0:
             raise RuntimeError('Error: fail to add syscall filter')
+        return r
+
+    def remove_syscall_filter(self, syscall_nb):
+        logging.debug('removing syscall filter on %s' % (syscall_nb))
+        c_syscall_nb = c_ulonglong(syscall_nb)
+        r = self.make_ioctl(self.KVM_NITRO_REMOVE_SYSCALL_FILTER,
+                            byref(c_syscall_nb))
+        if r != 0:
+            raise RuntimeError('Error: fail to remove syscall filter')
         return r
 
 class VCPU(IOCTL):

--- a/nitro/kvm.py
+++ b/nitro/kvm.py
@@ -6,93 +6,98 @@ from ioctl_opt import IO, IOR, IOW
 KVMIO = 0xAE
 NITRO_MAX_VCPUS = 64
 
+
 class DTable(Structure):
     _fields_ = [
-                ('base', c_ulonglong),
-                ('limit', c_ushort),
-                ('padding', c_ushort * 3),
-            ]
+        ('base', c_ulonglong),
+        ('limit', c_ushort),
+        ('padding', c_ushort * 3),
+    ]
+
 
 class Segment(Structure):
     _fields_ = [
-                ('base', c_ulonglong),
-                ('limit', c_uint),
-                ('selector', c_ushort),
-                ('type', c_ubyte),
-                ('present', c_ubyte),
-                ('dpl', c_ubyte),
-                ('db', c_ubyte),
-                ('s', c_ubyte),
-                ('l', c_ubyte),
-                ('g', c_ubyte),
-                ('avl', c_ubyte),
-                ('unusable', c_ubyte),
-                ('padding', c_ubyte),
-            ]
+        ('base', c_ulonglong),
+        ('limit', c_uint),
+        ('selector', c_ushort),
+        ('type', c_ubyte),
+        ('present', c_ubyte),
+        ('dpl', c_ubyte),
+        ('db', c_ubyte),
+        ('s', c_ubyte),
+        ('l', c_ubyte),
+        ('g', c_ubyte),
+        ('avl', c_ubyte),
+        ('unusable', c_ubyte),
+        ('padding', c_ubyte),
+    ]
+
 
 class SRegs(Structure):
     _fields_ = [
-                ('cs', Segment),
-                ('ds', Segment),
-                ('es', Segment),
-                ('fs', Segment),
-                ('gs', Segment),
-                ('ss', Segment),
-                ('tr', Segment),
-                ('ldt', Segment),
-                ('gdt', DTable),
-                ('idt', DTable),
-                ('cr0', c_ulonglong),
-                ('cr2', c_ulonglong),
-                ('cr3', c_ulonglong),
-                ('cr4', c_ulonglong),
-                ('cr8', c_ulonglong),
-                ('efer', c_ulonglong),
-                ('apic_base', c_ulonglong),
-                ('interrupt_bitmap', c_ulonglong * ((256 + 63) // 64)),
-            ]
+        ('cs', Segment),
+        ('ds', Segment),
+        ('es', Segment),
+        ('fs', Segment),
+        ('gs', Segment),
+        ('ss', Segment),
+        ('tr', Segment),
+        ('ldt', Segment),
+        ('gdt', DTable),
+        ('idt', DTable),
+        ('cr0', c_ulonglong),
+        ('cr2', c_ulonglong),
+        ('cr3', c_ulonglong),
+        ('cr4', c_ulonglong),
+        ('cr8', c_ulonglong),
+        ('efer', c_ulonglong),
+        ('apic_base', c_ulonglong),
+        ('interrupt_bitmap', c_ulonglong * ((256 + 63) // 64)),
+    ]
+
 
 class Regs(Structure):
     _fields_ = [
-                ('rax', c_ulonglong),
-                ('rbx', c_ulonglong),
-                ('rcx', c_ulonglong),
-                ('rdx', c_ulonglong),
-                ('rsi', c_ulonglong),
-                ('rdi', c_ulonglong),
-                ('rsp', c_ulonglong),
-                ('rbp', c_ulonglong),
-                ('r8', c_ulonglong),
-                ('r9', c_ulonglong),
-                ('r10', c_ulonglong),
-                ('r11', c_ulonglong),
-                ('r12', c_ulonglong),
-                ('r13', c_ulonglong),
-                ('r14', c_ulonglong),
-                ('r15', c_ulonglong),
-                ('rip', c_ulonglong),
-                ('rflags', c_ulonglong),
-            ]
+        ('rax', c_ulonglong),
+        ('rbx', c_ulonglong),
+        ('rcx', c_ulonglong),
+        ('rdx', c_ulonglong),
+        ('rsi', c_ulonglong),
+        ('rdi', c_ulonglong),
+        ('rsp', c_ulonglong),
+        ('rbp', c_ulonglong),
+        ('r8', c_ulonglong),
+        ('r9', c_ulonglong),
+        ('r10', c_ulonglong),
+        ('r11', c_ulonglong),
+        ('r12', c_ulonglong),
+        ('r13', c_ulonglong),
+        ('r14', c_ulonglong),
+        ('r15', c_ulonglong),
+        ('rip', c_ulonglong),
+        ('rflags', c_ulonglong),
+    ]
+
 
 class NitroEventStr(Structure):
     _fields_ = [
-                ('present', c_bool),
-                ('direction', c_uint),
-                ('type', c_uint),
-                ('regs', Regs),
-                ('sregs', SRegs),
-            ]
+        ('present', c_bool),
+        ('direction', c_uint),
+        ('type', c_uint),
+        ('regs', Regs),
+        ('sregs', SRegs),
+    ]
+
 
 class NitroVCPUs(Structure):
     _fields_ = [
-                ('num_vcpus', c_int),
-                ('ids', c_int * NITRO_MAX_VCPUS),
-                ('fds', c_int * NITRO_MAX_VCPUS),
-            ]
+        ('num_vcpus', c_int),
+        ('ids', c_int * NITRO_MAX_VCPUS),
+        ('fds', c_int * NITRO_MAX_VCPUS),
+    ]
 
 
 class IOCTL:
-
     __slots__ = (
         'libc',
         'fd'
@@ -112,8 +117,8 @@ class IOCTL:
     def close(self):
         os.close(self.fd)
 
-class KVM(IOCTL):
 
+class KVM(IOCTL):
     __slots__ = (
         'kvm_file'
     )
@@ -135,8 +140,8 @@ class KVM(IOCTL):
             raise RuntimeError('Error: fail to attach to the VM')
         return r
 
-class VM(IOCTL):
 
+class VM(IOCTL):
     __slots__ = (
         'vcpus_struct'
     )
@@ -153,10 +158,12 @@ class VM(IOCTL):
 
     def attach_vcpus(self):
         logging.debug('attach_vcpus')
-        r = self.make_ioctl(self.KVM_NITRO_ATTACH_VCPUS, byref(self.vcpus_struct))
+        r = self.make_ioctl(self.KVM_NITRO_ATTACH_VCPUS,
+                            byref(self.vcpus_struct))
         if r != 0:
             raise RuntimeError('Error: fail to attach to vcpus')
-        vcpus = [VCPU(i, self.vcpus_struct.fds[i]) for i in range(self.vcpus_struct.num_vcpus)]
+        vcpus = [VCPU(i, self.vcpus_struct.fds[i]) for i in
+                 range(self.vcpus_struct.num_vcpus)]
         return vcpus
 
     def set_syscall_trap(self, enabled):
@@ -168,7 +175,8 @@ class VM(IOCTL):
     def add_syscall_filter(self, syscall_nb):
         logging.debug('adding syscall filter on %s' % (syscall_nb))
         c_syscall_nb = c_ulonglong(syscall_nb)
-        r = self.make_ioctl(self.KVM_NITRO_ADD_SYSCALL_FILTER, byref(c_syscall_nb))
+        r = self.make_ioctl(self.KVM_NITRO_ADD_SYSCALL_FILTER,
+                            byref(c_syscall_nb))
         if r != 0:
             raise RuntimeError('Error: fail to add syscall filter')
         return r
@@ -182,8 +190,8 @@ class VM(IOCTL):
             raise RuntimeError('Error: fail to remove syscall filter')
         return r
 
-class VCPU(IOCTL):
 
+class VCPU(IOCTL):
     __slots__ = (
         'vcpu_nb',
     )
@@ -205,7 +213,8 @@ class VCPU(IOCTL):
         nitro_ev = NitroEventStr()
         ret = self.make_ioctl(self.KVM_NITRO_GET_EVENT, byref(nitro_ev))
         if ret != 0:
-            logging.error("get_event failed (vcpu: %d; returned: %d)", self.vcpu_nb, ret)
+            logging.error("get_event failed (vcpu: %d; returned: %d)",
+                          self.vcpu_nb, ret)
             raise ValueError("get_event failed")
         return nitro_ev
 

--- a/nitro/libvmi.py
+++ b/nitro/libvmi.py
@@ -1,6 +1,7 @@
 import logging
 from enum import Enum
 
+
 from nitro._libvmi import ffi, lib
 
 VMI_SUCCESS = 0
@@ -13,6 +14,7 @@ class VMIOS(Enum):
     UNKNOWN = 0
     LINUX = 1
     WINDOWS = 2
+
 
 class Libvmi:
 
@@ -41,7 +43,6 @@ class Libvmi:
             raise LibvmiError('VMI_FAILURE')
         # store handle to real vmi_instance_t
         self.vmi = self.opaque_vmi[0]
-        self.failures = 0
 
     def destroy(self):
         status = lib.vmi_destroy(self.vmi)

--- a/nitro/listener.py
+++ b/nitro/listener.py
@@ -156,3 +156,6 @@ class Listener:
 
     def add_syscall_filter(self, syscall_nb):
         self.vm_io.add_syscall_filter(syscall_nb)
+
+    def remove_syscall_filter(self, syscall_nb):
+        self.vm_io.remove_syscall_filter(syscall_nb)

--- a/nitro/listener.py
+++ b/nitro/listener.py
@@ -13,7 +13,7 @@ from nitro.kvm import KVM, VM
 
 
 def find_qemu_pid(vm_name):
-    logging.info('Finding QEMU pid for domain {}'.format(vm_name))
+    logging.info('Finding QEMU pid for domain %s', vm_name)
     libvirt_vm_pid_file = '/var/run/libvirt/qemu/{}.pid'.format(vm_name)
     try:
         with open(libvirt_vm_pid_file, 'r') as f:
@@ -74,7 +74,7 @@ class Listener:
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, *args, **kwargs):
         self.stop()
 
     def stop(self):
@@ -124,7 +124,8 @@ class Listener:
             else:
                 e = NitroEvent(nitro_raw_ev, vcpu_io)
                 # put the event in the queue
-                # and wait for the event to be processed, when the main thread will set the continue_event
+                # and wait for the event to be processed,
+                # when the main thread will set the continue_event
                 item = (e, continue_event)
                 queue.put(item)
                 continue_event.wait()
@@ -147,7 +148,7 @@ class Listener:
             # ack the rest of the threads
             while [f for f in self.futures if f.running()]:
                 if self.queue.full():
-                    (event, continue_event) = self.queue.get()
+                    (*rest, continue_event) = self.queue.get()
                     continue_event.set()
                 # let the threads terminate
                 time.sleep(0.1)

--- a/nitro/listener.py
+++ b/nitro/listener.py
@@ -153,3 +153,6 @@ class Listener:
                 time.sleep(0.1)
             # wait for threads to exit
             wait(self.futures)
+
+    def add_syscall_filter(self, syscall_nb):
+        self.vm_io.add_syscall_filter(syscall_nb)

--- a/nitro/nitro.py
+++ b/nitro/nitro.py
@@ -16,7 +16,7 @@ class Nitro:
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, *args, **kwargs):
         self.stop()
 
     def stop(self):

--- a/nitro/nitro.py
+++ b/nitro/nitro.py
@@ -3,12 +3,12 @@ from nitro.backends import get_backend
 
 class Nitro:
 
-    def __init__(self, domain, introspection=True):
+    def __init__(self, domain, introspection=True, syscall_filtering=True):
         self.listener = Listener(domain)
         self.introspection = introspection
         self.backend = None
         if self.introspection:
-            self.backend = get_backend(domain)
+            self.backend = get_backend(domain, self.listener, syscall_filtering)
 
     def listen(self):
         yield from self.listener.listen()

--- a/nitro/nitro.py
+++ b/nitro/nitro.py
@@ -17,6 +17,9 @@ class Nitro:
         return self
 
     def __exit__(self, type, value, traceback):
+        self.stop()
+
+    def stop(self):
         if self.backend is not None:
             self.backend.stop()
         self.listener.stop()

--- a/nitro/syscall.py
+++ b/nitro/syscall.py
@@ -1,6 +1,3 @@
-
-# FIXME:
-# Maybe we should subclass this for different backends
 class Syscall:
     __slots__ = (
         "event",
@@ -32,4 +29,3 @@ class Syscall:
         if self.args is not None and self.args.modified:
             info['modified'] = self.args.modified
         return info
-

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -305,7 +305,7 @@ class TestWindows(unittest.TestCase):
         binary_path = os.path.join(self.script_dir, 'binaries', 'createfile_write_data.exe')
         self.vm.cdrom.set_executable(binary_path)
 
-        def enter_NtCreateFile(syscall):
+        def enter_NtCreateFile(syscall, backend):
             DesiredAccess = syscall.args[1]
             object_attributes = syscall.args[2]
             obj = ObjectAttributes(object_attributes, syscall.process)


### PR DESCRIPTION
This PR fixes the performance issues of Nitro by moving the syscall filtering directly inside the kernel.

A new option `syscall_filtering`, `True` by default, has been added to the `Backend` constructor.

it is used by `define/undefine_hook` methods, to send an ioctl with the syscall number if enabled

