### PR TITLE
Fix stop nitro

### DIFF
--- a/nitro/libvmi.py
+++ b/nitro/libvmi.py
@@ -48,6 +48,7 @@ class Libvmi:
         status = lib.vmi_destroy(self.vmi)
         if status != VMI_SUCCESS:
             raise LibvmiError('VMI_FAILURE')
+        self.vmi = None
 
     def translate_ksym2v(self, symbol):
         addr = ffi.new("addr_t *")

--- a/nitro/nitro.py
+++ b/nitro/nitro.py
@@ -20,6 +20,6 @@ class Nitro:
         self.stop()
 
     def stop(self):
+        self.listener.stop()
         if self.backend is not None:
             self.backend.stop()
-        self.listener.stop()


### PR DESCRIPTION
When we stop Nitro, we were stopping the backend first, and then stopping the listener, which can lead to a situation where an event is still being processed while the backend is stopped.