### PR TITLE
Replace listeners use of pgrep with Python implementation

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,6 +17,7 @@ Depends: ${misc:Depends},
          python3-docopt,
          python3-libvirt,
          python,
+         python3-psutil,
          python-docopt,
 Description: Syscall interception library
   Nitro allows you to monitor your virtual machines using vmi techniques to

--- a/nitro/listener.py
+++ b/nitro/listener.py
@@ -24,8 +24,9 @@ def find_qemu_pid(vm_name):
             return pid
     except IOError:
         for proc in psutil.process_iter():
+            cmdline = proc.cmdline()[1:]
             if proc.name() == "qemu-system-x86_64" and \
-               any("guest={}".format(vm_name) in p for p in proc.cmdline()[1:]):
+               next((True for k, v in zip(cmdline, cmdline[1:]) if k == "-name" and vm_name in v), False):
                 return proc.pid
         logging.critical('Cannot find QEMU')
         raise QEMUNotFoundError('Cannot find QEMU')

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
         'cffi>=1.0.0',
         'docopt',
         'libvirt-python',
-        'ioctl_opt'
+        'ioctl_opt',
+        'psutil'
     ],
     extras_require={
         "docs": ["sphinx", "sphinx_rtd_theme"],


### PR DESCRIPTION
This pull requests removes the need for calling subprocess in listener by finding QEMU's PID using pure Python. Since we are only targeting Linux anyway for the hypervisor side, I guess losing some potential portability benefits of pgrep isn't a huge concern here. However, I understand if you feel that this change is unneeded. After all, pgrep is probably a more battle-tested solution. Regardless, this implementation seems to work fine for me.