### PR TITLE
Implemented system call filtering for Linux

### DIFF
--- a/nitro/backends/linux/backend.py
+++ b/nitro/backends/linux/backend.py
@@ -16,7 +16,7 @@ VOID_P_SIZE = sizeof(c_void_p)
 
 HANDLER_NAME_REGEX = re.compile(r"^(SyS|sys)_(?P<name>.+)")
 
-MAX_SYSTEM_CALL_COUNT = 512
+MAX_SYSTEM_CALL_COUNT = 1024
 
 class LinuxBackend(Backend):
     __slots__ = (
@@ -98,11 +98,12 @@ class LinuxBackend(Backend):
                 if symbol is not None:
                     mapping[symbol] = i
                 else:
-                    return mapping
+                    break
+        return mapping
 
     def find_syscall_nb(self, syscall_name):
         # What about thos compat_* handlers?
-        handler_regexp = re.compile(r"^(SyS|sys)_{}".format(syscall_name))
+        handler_regexp = re.compile(r"^(SyS|sys)_{}$".format(re.escape(syscall_name)))
         for full_name, ind in self.syscall_names.items():
             if handler_regexp.match(full_name) is not None:
                 return ind

--- a/nitro/backends/linux/backend.py
+++ b/nitro/backends/linux/backend.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import re
 
@@ -22,6 +23,7 @@ class LinuxBackend(Backend):
         "nb_vcpu",
         "syscall_stack",
         "tasks_offset",
+        "syscall_names",
         "mm_offset",
         "pgd_offset",
     )
@@ -35,6 +37,8 @@ class LinuxBackend(Backend):
         self.nb_vcpu = len(vcpus_info[0])
 
         self.syscall_stack = tuple([] for _ in range(self.nb_vcpu))
+
+        self.syscall_names = self.build_syscall_name_map()
 
         self.tasks_offset = self.libvmi.get_offset("linux_tasks")
         self.mm_offset = self.libvmi.get_offset("linux_mm")
@@ -76,6 +80,27 @@ class LinuxBackend(Backend):
         # translate the address into a name
         return self.libvmi.translate_v2ksym(addr)
 
+    def build_syscall_name_map(self):
+        # Its a bit difficult to know where the system call table ends, here we
+        # do something kind of risky and read as long as translate_v2ksym
+        # returns something that looks like a system call handler.
+        mapping = {}
+        for i in itertools.count():
+            p_addr = self.sys_call_table_addr + (i * VOID_P_SIZE)
+            addr = self.libvmi.read_addr_va(p_addr, 0)
+            symbol = self.libvmi.translate_v2ksym(addr)
+            if symbol is not None:
+                mapping[symbol] = i
+            else:
+                return mapping
+
+    def find_syscall_nb(self, syscall_name):
+        # What about thos compat_* handlers?
+        handler_regexp = re.compile(r"^(SyS|sys)_{}".format(syscall_name))
+        for full_name, ind in self.syscall_names.items():
+            if handler_regexp.match(full_name) is not None:
+                return ind
+
     def associate_process(self, cr3):
         """Get Process associated with CR3"""
         head = self.libvmi.translate_ksym2v("init_task") # get the address of swapper's task_struct
@@ -108,10 +133,18 @@ class LinuxBackend(Backend):
             self.remove_syscall_filter(name)
 
     def add_syscall_filter(self, syscall_name):
-        raise RuntimeError('Unimplemented feature')
+        syscall_nb = self.find_syscall_nb(syscall_name)
+        if syscall_nb is None:
+            raise RuntimeError(
+                'Unable to find syscall number for %s' % syscall_name)
+        self.listener.add_syscall_filter(syscall_nb)
 
     def remove_syscall_filter(self, syscall_name):
-        raise RuntimeError('Unimplemented feature')
+        syscall_nb = self.find_syscall_nb(syscall_name)
+        if syscall_nb is None:
+            raise RuntimeError(
+                'Unable to find syscall number for %s' % syscall_name)
+        self.listener.remove_syscall_filter(syscall_nb)
 
 
 def clean_name(name):

--- a/nitro/libvmi.py
+++ b/nitro/libvmi.py
@@ -68,7 +68,10 @@ class Libvmi:
         ctx = ffi.new("access_context_t *")
         ctx.translate_mechanism = lib.VMI_TM_PROCESS_PID
         str = lib.vmi_translate_v2ksym(self.vmi, ctx, vaddr)
-        return ffi.string(str).decode()
+        if str != ffi.NULL:
+            return ffi.string(str).decode()
+        else:
+            return None
 
     def translate_kv2p(self, vaddr):
         paddr = ffi.new("addr_t *")

--- a/nitro/libvmi.py
+++ b/nitro/libvmi.py
@@ -67,9 +67,9 @@ class Libvmi:
     def translate_v2ksym(self, vaddr):
         ctx = ffi.new("access_context_t *")
         ctx.translate_mechanism = lib.VMI_TM_PROCESS_PID
-        str = lib.vmi_translate_v2ksym(self.vmi, ctx, vaddr)
-        if str != ffi.NULL:
-            return ffi.string(str).decode()
+        string = lib.vmi_translate_v2ksym(self.vmi, ctx, vaddr)
+        if string != ffi.NULL:
+            return ffi.string(string).decode()
         else:
             return None
 

--- a/tests/vmtest_helper.py
+++ b/tests/vmtest_helper.py
@@ -59,10 +59,11 @@ class NitroThread(Thread):
         start_time = datetime.datetime.now()
 
         with Nitro(self.domain, self.analyze_enabled) as nitro:
-            for name, callback in self.enter_hooks.items():
-                nitro.backend.define_hook(name, callback, direction=SyscallDirection.enter)
-            for name, callback in self.exit_hooks.items():
-                nitro.backend.define_hook(name, callback, direction=SyscallDirection.exit)
+            if self.analyze_enabled:
+                for name, callback in self.enter_hooks.items():
+                    nitro.backend.define_hook(name, callback, direction=SyscallDirection.enter)
+                for name, callback in self.exit_hooks.items():
+                    nitro.backend.define_hook(name, callback, direction=SyscallDirection.exit)
             nitro.listener.set_traps(True)
             if self.ready_event is not None:
                 self.ready_event.set() # is this really necessary

--- a/tests/vmtest_helper.py
+++ b/tests/vmtest_helper.py
@@ -53,34 +53,31 @@ class NitroThread(Thread):
         self.total_time = None
         self.events = []
         self.ready_event = ready_event
+        self.nitro = Nitro(self.domain, self.analyze_enabled)
 
     def run(self):
         # start timer
         start_time = datetime.datetime.now()
-
-        with Nitro(self.domain, self.analyze_enabled) as nitro:
+        if self.analyze_enabled:
+            for name, callback in self.enter_hooks.items():
+                self.nitro.backend.define_hook(name, callback, direction=SyscallDirection.enter)
+            for name, callback in self.exit_hooks.items():
+                self.nitro.backend.define_hook(name, callback, direction=SyscallDirection.exit)
+        self.nitro.listener.set_traps(True)
+        if self.ready_event is not None:
+            self.ready_event.set() # is this really necessary
+        for event in self.nitro.listen():
             if self.analyze_enabled:
-                for name, callback in self.enter_hooks.items():
-                    nitro.backend.define_hook(name, callback, direction=SyscallDirection.enter)
-                for name, callback in self.exit_hooks.items():
-                    nitro.backend.define_hook(name, callback, direction=SyscallDirection.exit)
-            nitro.listener.set_traps(True)
-            if self.ready_event is not None:
-                self.ready_event.set() # is this really necessary
-            for event in nitro.listen():
-                if self.analyze_enabled:
-                    try:
-                        syscall = nitro.backend.process_event(event)
-                    except LibvmiError:
-                        ev_info = event.as_dict()
-                    else:
-                        ev_info = syscall.as_dict()
-                else:
+                try:
+                    syscall = self.nitro.backend.process_event(event)
+                except LibvmiError:
                     ev_info = event.as_dict()
-                self.events.append(ev_info)
-                if self.stop_request.isSet():
-                    logging.info("Stopping")
-                    break
+                else:
+                    ev_info = syscall.as_dict()
+            else:
+                ev_info = event.as_dict()
+            self.events.append(ev_info)
+
 
         # stop timer
         self.ready_event.clear()
@@ -88,7 +85,7 @@ class NitroThread(Thread):
         self.total_time = str(stop_time - start_time)
 
     def stop(self):
-        self.stop_request.set()
+        self.nitro.stop()
         self.join()
 
 


### PR DESCRIPTION
This adds system call filtering support for Linux back end. This is a bit ugly since we do not have a nice way of knowing how long the system call table is going to be so we just keep on going as long as we get proper symbols out of `translate_v2ksym`.