### PR TITLE
Install Nitro as an application

### DIFF
--- a/main.py
+++ b/main.py
@@ -71,7 +71,9 @@ class NitroRunner:
         self.nitro.stop()
 
 
-def main(args):
+def main():
+    init_logger()
+    args = docopt(__doc__)
     vm_name = args['<vm_name>']
     analyze_enabled = False if args['--nobackend'] else True
     output = args['--out']
@@ -80,5 +82,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-    init_logger()
-    main(docopt(__doc__))
+    main()

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@
 """Nitro.
 
 Usage:
-  nitro.py [options] <vm_name>
+  nitro [options] <vm_name>
 
 Options:
   -h --help            Show this screen

--- a/setup.py
+++ b/setup.py
@@ -2,20 +2,28 @@
 
 from setuptools import setup, find_packages
 
+with open("README.md", "r") as handle:
+    long_description = handle.read()
+
 setup(
     name="nitro",
     version="0.0.1",
     author="F-Secure Corporation",
     author_email="mathieu.tarral@gmail.com",
-    description=("""Hypervisor based tracing and monitoring prototype to trap
-        guest syscalls and analyze them"""),
+    description="Hypervisor based tracing and monitoring prototype to trap guest syscalls and analyze them",
+    long_description=long_description,
     packages=find_packages(),
     setup_requires=["cffi>=1.0.0"],
     cffi_modules=["nitro/build_libvmi.py:ffibuilder"],
+    entry_points={
+        "console_scripts": [
+            "nitro = main:main"
+        ]
+    },
     install_requires=[
         'cffi>=1.0.0',
         'docopt',
-        'libvirt-python',
+        'libvirt-python'
     ],
-    keywords="nitro hyperisor monitoring tracing syscall",
+    keywords=["nitro", "hyperisor", "monitoring", "tracing", "syscall"]
 )

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     author_email="mathieu.tarral@gmail.com",
     description="Hypervisor based tracing and monitoring prototype to trap guest syscalls and analyze them",
     long_description=long_description,
+    url="https://github.com/KVM-VMI/nitro",
     packages=find_packages(),
     setup_requires=["cffi>=1.0.0"],
     cffi_modules=["nitro/build_libvmi.py:ffibuilder"],
@@ -23,7 +24,12 @@ setup(
     install_requires=[
         'cffi>=1.0.0',
         'docopt',
-        'libvirt-python'
+        'libvirt-python',
+        'ioctl_opt'
     ],
+    extras_require={
+        "docs": ["sphinx", "sphinx_rtd_theme"],
+        "tests": ["nose2"]
+    },
     keywords=["nitro", "hyperisor", "monitoring", "tracing", "syscall"]
 )

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,12 @@
 
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as handle:
-    long_description = handle.read()
-
 setup(
     name="nitro",
     version="0.0.1",
     author="F-Secure Corporation",
     author_email="mathieu.tarral@gmail.com",
     description="Hypervisor based tracing and monitoring prototype to trap guest syscalls and analyze them",
-    long_description=long_description,
     url="https://github.com/KVM-VMI/nitro",
     packages=find_packages(),
     setup_requires=["cffi>=1.0.0"],


### PR DESCRIPTION
This pull requests modifies `setup.py` to install Nitro as an application that can be invoked with `nitro` command. Previously, Nitro only installed the libraries but not the command line entry point, or at least that's my understanding.

Additionally, the pull request fills out the long_description field with contents of README.md