### PR TITLE
downgrade cffi to use API v0.8.6 avail on debian jessie

### DIFF
--- a/nitro/build_libvmi.py
+++ b/nitro/build_libvmi.py
@@ -1,15 +1,7 @@
 from cffi import FFI
-ffibuilder = FFI()
+ffi = FFI()
 
 c_def = """
-#define VMI_INIT_DOMAINNAME 1 /**< initialize using domain name */
-
-#define VMI_INIT_DOMAINID 2 /**< initialize using domain id */
-
-#define VMI_INIT_EVENTS 4 /**< initialize events */
-
-#define VMI_INIT_SHM 8 /**< initialize SHM mode */
-
 // vmi_instance_t
 typedef struct vmi_instance *vmi_instance_t;
 
@@ -187,17 +179,6 @@ void vmi_rvacache_flush(
     vmi_instance_t vmi);
 """
 
+ffi.cdef(c_def)
 
-
-ffibuilder.set_source("nitro._libvmi",
-    """
-    #include <libvmi/libvmi.h>
-    """,
-    libraries=['vmi'])   # or a list of libraries to link with
-    # (more arguments like setup.py's Extension class:
-    # include_dirs=[..], extra_objects=[..], and so on)
-
-ffibuilder.cdef(c_def)
-
-if __name__ == "__main__":
-    ffibuilder.compile(verbose=True)
+lib = ffi.verify('#include <libvmi/libvmi.h>', libraries=['vmi'])

--- a/nitro/libvmi.py
+++ b/nitro/libvmi.py
@@ -2,7 +2,14 @@ import logging
 from enum import Enum
 
 
-from nitro._libvmi import ffi, lib
+from nitro.build_libvmi import ffi, lib
+
+# cffi 0.8.6 doesn't parse # define
+# we have to put these constants here
+VMI_INIT_DOMAINNAME = 1
+VMI_INIT_DOMAINID = 2
+VMI_INIT_EVENTS = 4
+VMI_INIT_SHM = 8
 
 VMI_SUCCESS = 0
 VMI_FAILURE = 1
@@ -33,7 +40,7 @@ class Libvmi:
         # init libvmi
         status = lib.vmi_init_complete(self.opaque_vmi,
                                        vm_name.encode(),
-                                       lib.VMI_INIT_DOMAINNAME,
+                                       VMI_INIT_DOMAINNAME,
                                        ffi.NULL,
                                        lib.VMI_CONFIG_GLOBAL_FILE_ENTRY,
                                        ffi.NULL,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     description="Hypervisor based tracing and monitoring prototype to trap guest syscalls and analyze them",
     url="https://github.com/KVM-VMI/nitro",
     packages=find_packages(),
-    setup_requires=["cffi>=1.0.0"],
+    setup_requires=["cffi>=0.8.6"],
     cffi_modules=["nitro/build_libvmi.py:ffibuilder"],
     entry_points={
         "console_scripts": [
@@ -18,7 +18,7 @@ setup(
         ]
     },
     install_requires=[
-        'cffi>=1.0.0',
+        'cffi>=0.8.6',
         'docopt',
         'libvirt-python',
         'ioctl_opt'


### PR DESCRIPTION
This downgrades build_libvmi.py to make it compatible with python3-cffi v0.8.6 available on Debian Jessie