### PR TITLE
Fix log message in define_hook

### DIFF
--- a/nitro/backends/backend.py
+++ b/nitro/backends/backend.py
@@ -59,7 +59,7 @@ class Backend:
                 self.stats['hooks_processed'] += 1
 
     def define_hook(self, name, callback, direction=SyscallDirection.enter):
-        dir_str = "entry" if SyscallDirection.enter else "exit"
+        dir_str = "entry" if direction == SyscallDirection.enter else "exit"
         logging.info('Defining %s hook on %s', dir_str, name)
         self.hooks[direction][name] = callback
 

--- a/nitro/backends/backend.py
+++ b/nitro/backends/backend.py
@@ -59,8 +59,7 @@ class Backend:
                 self.stats['hooks_processed'] += 1
 
     def define_hook(self, name, callback, direction=SyscallDirection.enter):
-        dir_str = "entry" if direction == SyscallDirection.enter else "exit"
-        logging.info('Defining %s hook on %s', dir_str, name)
+        logging.info('Defining %s hook on %s', direction.name, name)
         self.hooks[direction][name] = callback
 
     def undefine_hook(self, name, direction=SyscallDirection.enter):


### PR DESCRIPTION
Previously all hooks were logged as being entry hooks.