### PR TITLE
fix os close in kvm.py

### DIFF
--- a/nitro/kvm.py
+++ b/nitro/kvm.py
@@ -115,7 +115,12 @@ class IOCTL:
         return self.libc.ioctl(self.fd, request, arg)
 
     def close(self):
-        os.close(self.fd)
+        try:
+            os.close(self.fd)
+        except OSError:
+            # Bad file descriptor
+            # already closed
+            pass
 
 
 class KVM(IOCTL):


### PR DESCRIPTION
Sometimes the file descriptor has already been closed.
This catches the OSError exception