### PR TITLE
fix logging output

### DIFF
--- a/nitro/backends/windows/backend.py
+++ b/nitro/backends/windows/backend.py
@@ -94,7 +94,6 @@ supports 66-bit Windows 7 guests."""
                     full_name = e[1]["symbol"]["symbol"]
                     # add entry  to our current ssdt
                     cur_ssdt[entry] = full_name
-                    logging.debug('Add SSDT entry [%s] -> %s', entry, full_name)
         # save rekall symbols
         self.symbols = symbols
 

--- a/nitro/kvm.py
+++ b/nitro/kvm.py
@@ -206,7 +206,7 @@ class VM(IOCTL):
         return r
 
     def add_syscall_filter(self, syscall_nb):
-        logging.debug('adding syscall filter on %s' % (syscall_nb))
+        logging.debug('adding syscall filter on %s' % (hex(syscall_nb)))
         c_syscall_nb = c_ulonglong(syscall_nb)
         r = self.make_ioctl(self.KVM_NITRO_ADD_SYSCALL_FILTER,
                             byref(c_syscall_nb))
@@ -215,7 +215,7 @@ class VM(IOCTL):
         return r
 
     def remove_syscall_filter(self, syscall_nb):
-        logging.debug('removing syscall filter on %s' % (syscall_nb))
+        logging.debug('removing syscall filter on %s' % (hex(syscall_nb)))
         c_syscall_nb = c_ulonglong(syscall_nb)
         r = self.make_ioctl(self.KVM_NITRO_REMOVE_SYSCALL_FILTER,
                             byref(c_syscall_nb))


### PR DESCRIPTION
remove printing every SSDT entries in Windows
print syscall number in hexadecimal