### PR TITLE
listener: rework stop method, avoid race condition

### DIFF
--- a/nitro/nitro.py
+++ b/nitro/nitro.py
@@ -19,5 +19,5 @@ class Nitro:
     def __exit__(self, *args, **kwargs):
         self.stop()
 
-    def stop(self):
-        self.listener.stop()
+    def stop(self, synchronous=True):
+        self.listener.stop(synchronous)


### PR DESCRIPTION
remove the stop_listen method, because a lot of the code was duplicated to just consume the rest of the events, and this already done by listen itself.